### PR TITLE
Add new parameter for defining reference timeout.

### DIFF
--- a/templates/ros2_control/controller/dummy_controller.cpp
+++ b/templates/ros2_control/controller/dummy_controller.cpp
@@ -40,9 +40,11 @@ static constexpr rmw_qos_profile_t rmw_qos_profile_services_hist_keep_all = {
 using ControllerReferenceMsg = dummy_package_namespace::DummyClassName::ControllerReferenceMsg;
 
 // called from RT control loop
-void reset_controller_reference_msg(
-  std::shared_ptr<ControllerReferenceMsg> & msg, const std::vector<std::string> & joint_names)
+void reset_controller_command_msg(
+  std::shared_ptr<ControllerCommandMsg> & msg, const std::vector<std::string> & joint_names,
+  const std::shared_ptr<rclcpp::Node> & node)
 {
+  msg->header.stamp = node->now();
   msg->joint_names = joint_names;
   msg->displacements.resize(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
   msg->velocities.resize(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
@@ -94,6 +96,7 @@ controller_interface::CallbackReturn DummyClassName::on_configure(
   subscribers_qos.best_effort();
 
   // Reference Subscriber
+  ref_timeout_ = rclcpp::Duration::from_seconds(params_.reference_timeout);
   ref_subscriber_ = get_node()->create_subscription<ControllerReferenceMsg>(
     "~/reference", subscribers_qos,
     std::bind(&DummyClassName::reference_callback, this, std::placeholders::_1));
@@ -141,13 +144,27 @@ controller_interface::CallbackReturn DummyClassName::on_configure(
 
 void DummyClassName::reference_callback(const std::shared_ptr<ControllerReferenceMsg> msg)
 {
+  // if no timestamp provided use current time for command timestamp
+  if (msg->header.stamp.sec == 0 && msg->header.stamp.nanosec == 0u) {
+    RCLCPP_WARN(
+      get_node()->get_logger(),
+      "Timestamp in header is missing, using current time as command timestamp.")
+    msg->header.stamp = get_node()->now();
+  }
   if (msg->joint_names.size() == params_.joints.size()) {
-    input_ref_.writeFromNonRT(msg);
+    if (msg->header.stamp < (get_node()->now() + ref_timeout_)) {
+      input_ref_.writeFromNonRT(msg);
+    } else {
+      RCLCPP_ERROR(
+        get_node()->get_logger(),
+        "Received message has timestamp %.10f older then allowed timeout at timestamp %.10f",
+        msg->joint_names.size(), params_.joints.size());
+    }
   } else {
     RCLCPP_ERROR(
       get_node()->get_logger(),
       "Received %zu , but expected %zu joints in command. Ignoring message.",
-      msg->joint_names.size(), params_.joints.size());
+      rclcpp::Time(msg->header.stamp).seconds(), get_node()->now().seconds());
   }
 }
 
@@ -205,16 +222,20 @@ controller_interface::return_type DummyClassName::update(
   const rclcpp::Time & time, const rclcpp::Duration & /*period*/)
 {
   auto current_ref = input_ref_.readFromRT();
+  const auto age_of_last_command = time - (*current_cmd)->header.stamp;
 
   // TODO(anyone): depending on number of interfaces, use definitions, e.g., `CMD_MY_ITFS`,
   // instead of a loop
   for (size_t i = 0; i < command_interfaces_.size(); ++i) {
-    if (!std::isnan((*current_ref)->displacements[i])) {
-      if (*(control_mode_.readFromRT()) == control_mode_type::SLOW) {
-        (*current_ref)->displacements[i] /= 2;
+    // send message only if there is no timeout
+    if (age_of_last_command <= ref_timeout_) {
+      if (!std::isnan((*current_ref)->displacements[i])) {
+        if (*(control_mode_.readFromRT()) == control_mode_type::SLOW) {
+          (*current_ref)->displacements[i] /= 2;
+        }
+        command_interfaces_[i].set_value((*current_ref)->displacements[i]);
       }
-      command_interfaces_[i].set_value((*current_ref)->displacements[i]);
-
+    } else {
       (*current_ref)->displacements[i] = std::numeric_limits<double>::quiet_NaN();
     }
   }

--- a/templates/ros2_control/controller/dummy_controller.yaml
+++ b/templates/ros2_control/controller/dummy_controller.yaml
@@ -29,3 +29,11 @@ dummy_controller:
       forbidden_interface_name_prefix: null
     }
   }
+  reference_timeout: {
+    type: double,
+    default_value: 0.0,
+    description: "Timeout for controller references after which they will be reset. This is especially useful for controllers that can cause unwanted and dangerous behaviour if reference is not reset, e.g., velocity controllers. If value is 0 the reference is reset after each run.",
+    validation: {
+      gt_eq<>: 0.0,
+    }
+  }

--- a/templates/ros2_control/controller/dummy_controller_params.yaml
+++ b/templates/ros2_control/controller/dummy_controller_params.yaml
@@ -5,3 +5,5 @@ test_dummy_controller:
       - joint1
 
     interface_name: acceleration
+
+    command_timeout: 0.1

--- a/templates/ros2_control/controller/dummy_controller_preceeding_params.yaml
+++ b/templates/ros2_control/controller/dummy_controller_preceeding_params.yaml
@@ -7,3 +7,5 @@ test_dummy_controller:
 
     state_joints:
       - joint1state
+
+    command_timeout: 0.1

--- a/templates/ros2_control/controller/dummy_package_namespace/dummy_controller.hpp
+++ b/templates/ros2_control/controller/dummy_package_namespace/dummy_controller.hpp
@@ -15,6 +15,7 @@
 #ifndef TEMPLATES__ROS2_CONTROL__CONTROLLER__DUMMY_PACKAGE_NAMESPACE__DUMMY_CONTROLLER_HPP_
 #define TEMPLATES__ROS2_CONTROL__CONTROLLER__DUMMY_PACKAGE_NAMESPACE__DUMMY_CONTROLLER_HPP_
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -91,6 +92,7 @@ protected:
   // Command subscribers and Controller State publisher
   rclcpp::Subscription<ControllerReferenceMsg>::SharedPtr ref_subscriber_ = nullptr;
   realtime_tools::RealtimeBuffer<std::shared_ptr<ControllerReferenceMsg>> input_ref_;
+  rclcpp::Duration ref_timeout_ = rclcpp::Duration::from_seconds(0.0);  // 0ms
 
   rclcpp::Service<ControllerModeSrvType>::SharedPtr set_slow_control_mode_service_;
   realtime_tools::RealtimeBuffer<control_mode_type> control_mode_;

--- a/templates/ros2_control/controller/test_dummy_controller.hpp
+++ b/templates/ros2_control/controller/test_dummy_controller.hpp
@@ -53,6 +53,7 @@ class TestableDummyClassName : public dummy_package_namespace::DummyClassName
   FRIEND_TEST(DummyClassNameTest, test_setting_slow_mode_service);
   FRIEND_TEST(DummyClassNameTest, test_update_logic_fast);
   FRIEND_TEST(DummyClassNameTest, test_update_logic_slow);
+  FRIEND_TEST(DummyClassNameTest, test_message_timeout);
 
 public:
   controller_interface::CallbackReturn on_configure(
@@ -150,6 +151,13 @@ protected:
     // TODO(anyone): Add other state interfaces, if any
 
     controller_->assign_interfaces(std::move(command_ifs), std::move(state_ifs));
+
+    //     if (set_parameters) {
+    //       controller_->get_node()->set_parameter({"joints", joint_names_});
+    //       controller_->get_node()->set_parameter({"state_joints", state_joint_names_});
+    //       controller_->get_node()->set_parameter({"interface_name", interface_name_});
+    //       controller_->get_node()->set_parameter({"refrence_timeout", ref_timeout_});
+    //     }
   }
 
   void subscribe_and_get_messages(ControllerStateMsg & msg)
@@ -187,7 +195,7 @@ protected:
 
   // TODO(anyone): add/remove arguments as it suites your command message type
   void publish_commands(
-    const std::vector<double> & displacements = {0.45},
+    const rclcpp::Time & stamp, const std::vector<double> & displacements = {0.45},
     const std::vector<double> & velocities = {0.0}, const double duration = 1.25)
   {
     auto wait_for_topic = [&](const auto topic_name) {
@@ -206,6 +214,7 @@ protected:
     wait_for_topic(command_publisher_->get_topic_name());
 
     ControllerReferenceMsg msg;
+    msg.header.stamp = stamp;
     msg.joint_names = joint_names_;
     msg.displacements = displacements;
     msg.velocities = velocities;
@@ -244,6 +253,8 @@ protected:
 
   std::vector<hardware_interface::StateInterface> state_itfs_;
   std::vector<hardware_interface::CommandInterface> command_itfs_;
+
+  double ref_timeout_ = 0.2;
 
   // Test related parameters
   std::unique_ptr<TestableDummyClassName> controller_;


### PR DESCRIPTION
@robogir please take over this PR from here. To finish up the steps are the following:

The easiest way to tackle this is to generate a controller and then fix things in the generated code to get it working and doing in parallel the same changes in this template.

- [ ] make everything compile
- [ ] fix the tests for the standard controllers
- [ ] make the same changes in template for chained controller to support this parameter
