### PR TITLE
fix docker container creation

### DIFF
--- a/scripts/environment/setup.bash
+++ b/scripts/environment/setup.bash
@@ -16,7 +16,8 @@ source $script_own_dir/../_RosTeamWs_Docker_Defines.bash
 source $script_own_dir/../_Team_Defines.bash
 
 # ros distribution name will be set in $ros_distro
-check_and_set_ros_distro_and_version $1
+# RosTeamWS_WS_DOCKER_SUPPORT variable is set in .ros_team_ws_rc file and only true if docker is supported
+check_and_set_ros_distro_and_version $1 $RosTeamWS_WS_DOCKER_SUPPORT
 
 ws_folder="$2"
 if [ "$2" == "-" ]; then

--- a/templates/docker/nvidia.dockerfile
+++ b/templates/docker/nvidia.dockerfile
@@ -10,11 +10,10 @@ ARG home
 SHELL ["/bin/bash", "-c"]
 
 # upgrade to newest version
-RUN apt-get update -y && apt-get install -y nala
-RUN nala upgrade --assume-yes
+RUN apt-get update
 
 # install locales
-RUN nala install -y locales nala
+RUN apt-get install -y locales
 
 # Configure user env
 ENV TZ=Europe/Berlin
@@ -34,15 +33,15 @@ ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPA
 RUN locale
 
 # Install basic utilities
-RUN nala update && nala install -y git nano sudo tmux tree vim iputils-ping wget bash-completion pre-commit trash-cli gh
+RUN apt-get update && apt-get install -y git nano sudo tmux tree vim iputils-ping wget bash-completion trash-cli
 
 # install ROS2:ROS_DUMMY_VERSION dependencies
-RUN nala install -y curl gnupg gnupg2 lsb-release software-properties-common && apt-add-repository universe
+RUN apt-get install -y curl gnupg gnupg2 lsb-release software-properties-common && apt-add-repository universe
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
 # install ROS2:ROS_DUMMY_VERSION and things needed for ros development, DEBIAN_FRONTEND is needed to ignore interactive keyboard layout setting while install
-RUN nala update && DEBIAN_FRONTEND=noniteractive nala install -y ros-ROS_DUMMY_VERSION-desktop pip python3-colcon-common-extensions python3-vcstool
+RUN apt-get update && DEBIAN_FRONTEND=noniteractive apt-get install -y ros-ROS_DUMMY_VERSION-desktop pip python3-colcon-common-extensions python3-vcstool
 RUN pip install -U rosdep && \
     rosdep init
 

--- a/templates/docker/standard.dockerfile
+++ b/templates/docker/standard.dockerfile
@@ -10,11 +10,10 @@ ARG home
 SHELL ["/bin/bash", "-c"]
 
 # upgrade to newest version
-RUN apt-get update -y && apt-get install -y nala
-RUN nala upgrade --assume-yes
+RUN apt-get update -y
 
 # install locales
-RUN nala install -y locales nala
+RUN apt-get install -y locales
 
 # Configure user env
 ENV TZ=Europe/Berlin
@@ -31,15 +30,15 @@ ENV LC_ALL en_US.UTF-8
 RUN locale
 
 # Install basic utilities
-RUN nala update && nala install -y git nano sudo tmux tree vim iputils-ping wget bash-completion pre-commit trash-cli gh
+RUN apt-get update && apt-get install -y git nano sudo tmux tree vim iputils-ping wget bash-completion trash-cli
 
 # install ROS2:ROS_DUMMY_VERSION dependencies
-RUN nala install -y curl gnupg gnupg2 lsb-release software-properties-common && apt-add-repository universe
+RUN apt-get install -y curl gnupg gnupg2 lsb-release software-properties-common && apt-add-repository universe
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 
 # install ROS2:ROS_DUMMY_VERSION and things needed for ros development, DEBIAN_FRONTEND is needed to ignore interactive keyboard layout setting while install
-RUN nala update && DEBIAN_FRONTEND=noniteractive nala install -y ros-ROS_DUMMY_VERSION-desktop pip python3-colcon-common-extensions python3-vcstool
+RUN apt-get update && DEBIAN_FRONTEND=noniteractive apt-get install -y ros-ROS_DUMMY_VERSION-desktop pip python3-colcon-common-extensions python3-vcstool
 RUN pip install -U rosdep && \
     rosdep init
 


### PR DESCRIPTION
- nala not present in packages (ubuntu 20.04) not able to add nala -> reverted to apt-get so ubuntu 20.04 images can be build again
- sourcing was not working if ros-distro is not installed locally