### PR TITLE
add gpus arg if the count of nvidia devices is not zero

### DIFF
--- a/scripts/docker/_RosTeamWs_Docker_Defines.bash
+++ b/scripts/docker/_RosTeamWs_Docker_Defines.bash
@@ -93,7 +93,7 @@ RTW_Docker_create_docker_container () {
   xhost +local:docker
   docker run \
   --net=host \
-  --gpus all \
+  $([ $(ls -la /dev | grep nvidia | wc -l) "!=" "0" ] && echo "--gpus all") \
   -h ${docker_host_name} \
   -e DISPLAY \
   -e QT_X11_NO_MITSHM=1 \

--- a/templates/docker/recreate_docker.sh
+++ b/templates/docker/recreate_docker.sh
@@ -50,7 +50,7 @@ RTW_WS_create_docker_container_instance () {
   xhost +local:docker
   docker run \
   --net=host \
-  --gpus all \
+  $([ $(ls -la /dev | grep nvidia | wc -l) "!=" "0" ] && echo "--gpus all") \
   -h ${docker_host_name} \
   -e DISPLAY \
   -e QT_X11_NO_MITSHM=1 \


### PR DESCRIPTION
Similar issue: https://stackoverflow.com/questions/71461820/how-to-let-docker-run-gpus-all-gracefully-fall-back-to-cpu-if-gpu-is-not-pre