### PR TITLE
fix ros version needed to be installed

### DIFF
--- a/scripts/environment/setup.bash
+++ b/scripts/environment/setup.bash
@@ -16,7 +16,8 @@ source $script_own_dir/../_RosTeamWs_Docker_Defines.bash
 source $script_own_dir/../_Team_Defines.bash
 
 # ros distribution name will be set in $ros_distro
-check_and_set_ros_distro_and_version $1
+# RosTeamWS_WS_DOCKER_SUPPORT is set via .ros_team_ws_rc
+check_and_set_ros_distro_and_version $1 $RosTeamWS_WS_DOCKER_SUPPORT
 
 ws_folder="$2"
 if [ "$2" == "-" ]; then


### PR DESCRIPTION
There are currently two issues:
1. [x] Checking if a ROS version is installed locally or not should be skipped for docker based workspaces
2. [ ] Recent changes should be backported, otherwise there is some old logic inside the docker container which results in an error, because rolling is not installed (e.g. for Ubuntu 20.04 and foxy)
