### PR TITLE
Updating templates with developments from mecanum_controller

### DIFF
--- a/templates/ros2_control/controller/dummy_chainable_controller.cpp
+++ b/templates/ros2_control/controller/dummy_chainable_controller.cpp
@@ -123,7 +123,7 @@ controller_interface::CallbackReturn DummyClassName::on_configure(
   try {
     // State publisher
     s_publisher_ =
-      get_node()->create_publisher<ControllerStateMsg>("~/state", rclcpp::SystemDefaultsQoS());
+      get_node()->create_publisher<ControllerStateMsg>("~/controller_state", rclcpp::SystemDefaultsQoS());
     state_publisher_ = std::make_unique<ControllerStatePublisher>(s_publisher_);
   } catch (const std::exception & e) {
     fprintf(

--- a/templates/ros2_control/controller/dummy_chainable_controller.cpp
+++ b/templates/ros2_control/controller/dummy_chainable_controller.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Stogl Robotics Consulting UG (haftungsbeschränkt) (template)
+// Copyright (c) 2023, Stogl Robotics Consulting UG (haftungsbeschränkt) (template)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,8 +41,10 @@ using ControllerReferenceMsg = dummy_package_namespace::DummyClassName::Controll
 
 // called from RT control loop
 void reset_controller_reference_msg(
-  const std::shared_ptr<ControllerReferenceMsg> & msg, const std::vector<std::string> & joint_names)
+  const std::shared_ptr<ControllerReferenceMsg> & msg, const std::vector<std::string> & joint_names
+  const std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node)
 {
+  msg->header.stamp = node->now();
   msg->joint_names = joint_names;
   msg->displacements.resize(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
   msg->velocities.resize(joint_names.size(), std::numeric_limits<double>::quiet_NaN());
@@ -74,17 +76,17 @@ controller_interface::CallbackReturn DummyClassName::on_configure(
 {
   params_ = param_listener_->get_params();
 
-  if (!params_.state_joints.empty()) {
-    state_joints_ = params_.state_joints;
+  if (!params_.state_joint_names.empty()) {
+    state_joint_names_ = params_.state_joint_names;
   } else {
-    state_joints_ = params_.joints;
+    state_joint_names_ = params_.command_joint_names;
   }
 
-  if (params_.joints.size() != state_joints_.size()) {
+  if (params_.command_joint_names.size() != state_joint_names_.size()) {
     RCLCPP_FATAL(
       get_node()->get_logger(),
-      "Size of 'joints' (%d) and 'state_joints' (%d) parameters has to be the same!",
-      params_.joints.size(), state_joints_.size());
+      "Size of 'command_joint_names' (%d) and 'state_joint_names' (%d) parameters has to be the same!",
+      params_.command_joint_names.size(), state_joint_names_.size());
     return CallbackReturn::FAILURE;
   }
 
@@ -99,7 +101,7 @@ controller_interface::CallbackReturn DummyClassName::on_configure(
     std::bind(&DummyClassName::reference_callback, this, std::placeholders::_1));
 
   std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();
-  reset_controller_reference_msg(msg, params_.joints);
+  reset_controller_reference_msg(msg, params_.command_joint_names);
   input_ref_.writeFromNonRT(msg);
 
   auto set_slow_mode_service_callback =
@@ -132,7 +134,7 @@ controller_interface::CallbackReturn DummyClassName::on_configure(
 
   // TODO(anyone): Reserve memory in state publisher depending on the message type
   state_publisher_->lock();
-  state_publisher_->msg_.header.frame_id = params_.joints[0];
+  state_publisher_->msg_.header.frame_id = params_.command_joint_names[0];
   state_publisher_->unlock();
 
   RCLCPP_INFO(get_node()->get_logger(), "configure successful");
@@ -144,8 +146,8 @@ controller_interface::InterfaceConfiguration DummyClassName::command_interface_c
   controller_interface::InterfaceConfiguration command_interfaces_config;
   command_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
 
-  command_interfaces_config.names.reserve(params_.joints.size());
-  for (const auto & joint : params_.joints) {
+  command_interfaces_config.names.reserve(params_.command_joint_names.size());
+  for (const auto & joint : params_.command_joint_names) {
     command_interfaces_config.names.push_back(joint + "/" + params_.interface_name);
   }
 
@@ -157,8 +159,8 @@ controller_interface::InterfaceConfiguration DummyClassName::state_interface_con
   controller_interface::InterfaceConfiguration state_interfaces_config;
   state_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
 
-  state_interfaces_config.names.reserve(state_joints_.size());
-  for (const auto & joint : state_joints_) {
+  state_interfaces_config.names.reserve(state_joint_names_.size());
+  for (const auto & joint : state_joint_names_) {
     state_interfaces_config.names.push_back(joint + "/" + params_.interface_name);
   }
 
@@ -167,26 +169,38 @@ controller_interface::InterfaceConfiguration DummyClassName::state_interface_con
 
 void DummyClassName::reference_callback(const std::shared_ptr<ControllerReferenceMsg> msg)
 {
-  if (msg->joint_names.size() == params_.joints.size()) {
+  // if no timestamp provided use current time for command timestamp
+    if (msg->header.stamp.sec == 0 && msg->header.stamp.nanosec == 0u)
+  {
+    RCLCPP_WARN(
+      get_node()->get_logger(),
+      "Timestamp in header is missing, using current time as command "
+      "timestamp.");
+    msg->header.stamp = get_node()->now();
+  }
+  if (msg->joint_names.size() == params_.command_joint_names.size()) {
     input_ref_.writeFromNonRT(msg);
   } else {
     RCLCPP_ERROR(
       get_node()->get_logger(),
-      "Received %zu , but expected %zu joints in command. Ignoring message.",
-      msg->joint_names.size(), params_.joints.size());
+      "Received %zu , but expected %zu command_joint_names in command. Ignoring message.",
+      msg->joint_names.size(), params_.command_joint_names.size());
   }
 }
 
 std::vector<hardware_interface::CommandInterface> DummyClassName::on_export_reference_interfaces()
 {
-  reference_interfaces_.resize(state_joints_.size(), std::numeric_limits<double>::quiet_NaN());
+  reference_interfaces_.resize(NR_REF_ITFS, std::numeric_limits<double>::quiet_NaN());
 
   std::vector<hardware_interface::CommandInterface> reference_interfaces;
   reference_interfaces.reserve(reference_interfaces_.size());
 
+    std::vector<std::string> reference_interface_names = {
+    "linear/x/velocity", "linear/y/velocity", "angular/z/velocity"};
+
   for (size_t i = 0; i < reference_interfaces_.size(); ++i) {
     reference_interfaces.push_back(hardware_interface::CommandInterface(
-      get_node()->get_name(), state_joints_[i] + "/" + params_.interface_name,
+      get_node()->get_name(), reference_interface_names[i],
       &reference_interfaces_[i]));
   }
 
@@ -203,7 +217,7 @@ controller_interface::CallbackReturn DummyClassName::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
   // Set default value in command
-  reset_controller_reference_msg(*(input_ref_.readFromRT()), state_joints_);
+  reset_controller_reference_msg(*(input_ref_.readFromRT()), state_joint_names_, get_node());
 
   return controller_interface::CallbackReturn::SUCCESS;
 }
@@ -211,9 +225,9 @@ controller_interface::CallbackReturn DummyClassName::on_activate(
 controller_interface::CallbackReturn DummyClassName::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  // TODO(anyone): depending on number of interfaces, use definitions, e.g., `CMD_MY_ITFS`,
+  // TODO(anyone): depending on number of interfaces, use definitions, e.g., `NR_CMD_ITFS`,
   // instead of a loop
-  for (size_t i = 0; i < command_interfaces_.size(); ++i) {
+  for (size_t i = 0; i < NR_CMD_ITFS; ++i) {
     command_interfaces_[i].set_value(std::numeric_limits<double>::quiet_NaN());
   }
   return controller_interface::CallbackReturn::SUCCESS;
@@ -223,9 +237,9 @@ controller_interface::return_type DummyClassName::update_reference_from_subscrib
 {
   auto current_ref = input_ref_.readFromRT();
 
-  // TODO(anyone): depending on number of interfaces, use definitions, e.g., `CMD_MY_ITFS`,
+  // TODO(anyone): depending on number of interfaces, use definitions, e.g., `NR_CMD_ITFS`,
   // instead of a loop
-  for (size_t i = 0; i < reference_interfaces_.size(); ++i) {
+  for (size_t i = 0; i < NR_REF_ITFS; ++i) {
     if (!std::isnan((*current_ref)->displacements[i])) {
       reference_interfaces_[i] = (*current_ref)->displacements[i];
 
@@ -238,9 +252,9 @@ controller_interface::return_type DummyClassName::update_reference_from_subscrib
 controller_interface::return_type DummyClassName::update_and_write_commands(
   const rclcpp::Time & time, const rclcpp::Duration & /*period*/)
 {
-  // TODO(anyone): depending on number of interfaces, use definitions, e.g., `CMD_MY_ITFS`,
+  // TODO(anyone): depending on number of interfaces, use definitions, e.g., `NR_CMD_ITFS`,
   // instead of a loop
-  for (size_t i = 0; i < command_interfaces_.size(); ++i) {
+  for (size_t i = 0; i < NR_CMD_ITFS; ++i) {
     if (!std::isnan(reference_interfaces_[i])) {
       if (*(control_mode_.readFromRT()) == control_mode_type::SLOW) {
         reference_interfaces_[i] /= 2;
@@ -249,15 +263,22 @@ controller_interface::return_type DummyClassName::update_and_write_commands(
 
       reference_interfaces_[i] = std::numeric_limits<double>::quiet_NaN();
     }
+    else
+    {
+      command_interfaces_[i].set_value(0.0);
+    }
   }
 
   if (state_publisher_ && state_publisher_->trylock()) {
     state_publisher_->msg_.header.stamp = time;
-    state_publisher_->msg_.set_point = command_interfaces_[CMD_MY_ITFS].get_value();
+    state_publisher_->msg_.set_point = command_interfaces_[NR_CMD_ITFS].get_value();
 
     state_publisher_->unlockAndPublish();
   }
 
+  for (size_t i = 0; i < NR_REF_ITFS; ++i) {
+    reference_interfaces_[i] = std::numeric_limits<double>::quiet_NaN();
+  }
   return controller_interface::return_type::OK;
 }
 

--- a/templates/ros2_control/controller/dummy_controller.yaml
+++ b/templates/ros2_control/controller/dummy_controller.yaml
@@ -1,5 +1,5 @@
 dummy_controller:
-  joints: {
+  command_joint_names: {
     type: string_array,
     default_value: [],
     description: "Specifies joints used by the controller. If state joints parameter is defined, then only command joints are defined with this parameter.",
@@ -9,7 +9,7 @@ dummy_controller:
       not_empty<>: null,
     }
   }
-  state_joints: {
+  state_joint_names: {
     type: string_array,
     default_value: [],
     description: "(optional) Specifies joints for reading states. This parameter is only relevant when state joints are different then command joint, i.e., when a following controller is used.",
@@ -28,4 +28,13 @@ dummy_controller:
       one_of<>: [["position", "velocity", "acceleration", "effort",]],
       forbidden_interface_name_prefix: null
     }
+  }
+  reference_names: {
+    type: string_array,
+    default_value: [],
+    description: " Names of the references, ex: high level vel commands from MoveIt, Nav2, etc. 
+    Note: reference_names is intended to use in special cases only where reference names are not obvious.
+    For example 2D mobile robot with references linear_x, linear_y and angular_z is obvious case,
+    a custom robot that has custom references for the controller. A BETTER EXAMPLE HAS TO BE INCLUDED",
+    read_only: true,
   }

--- a/templates/ros2_control/controller/dummy_controller_params.yaml
+++ b/templates/ros2_control/controller/dummy_controller_params.yaml
@@ -1,7 +1,7 @@
 test_dummy_controller:
   ros__parameters:
 
-    joints:
+    command_joint_names:
       - joint1
 
     interface_name: acceleration

--- a/templates/ros2_control/controller/dummy_controller_preceeding_params.yaml
+++ b/templates/ros2_control/controller/dummy_controller_preceeding_params.yaml
@@ -1,9 +1,9 @@
 test_dummy_controller:
   ros__parameters:
-    joints:
+    command_joint_names:
       - joint1
 
     interface_name: acceleration
 
-    state_joints:
+    state_joint_names:
       - joint1state

--- a/templates/ros2_control/controller/dummy_package_namespace/dummy_chainable_controller.hpp
+++ b/templates/ros2_control/controller/dummy_package_namespace/dummy_chainable_controller.hpp
@@ -35,10 +35,13 @@
 namespace dummy_package_namespace
 {
 // name constants for state interfaces
-static constexpr size_t STATE_MY_ITFS = 0;
+static constexpr size_t NR_STATE_ITFS = 0;
 
 // name constants for command interfaces
-static constexpr size_t CMD_MY_ITFS = 0;
+static constexpr size_t NR_CMD_ITFS = 0;
+
+// name constants for reference interfaces
+static constexpr size_t NR_REF_ITFS = 0;
 
 // TODO(anyone: example setup for control mode (usually you will use some enums defined in messages)
 enum class control_mode_type : std::uint8_t {
@@ -89,7 +92,11 @@ protected:
   std::shared_ptr<dummy_controller::ParamListener> param_listener_;
   dummy_controller::Params params_;
 
-  std::vector<std::string> state_joints_;
+  std::vector<std::string> state_joint_names;
+  
+  // Names of the references, ex: high level vel commands from MoveIt, Nav2, etc.
+  // used for preceding controller
+  std::vector<std::string> reference_names_;
 
   // Command subscribers and Controller State publisher
   rclcpp::Subscription<ControllerReferenceMsg>::SharedPtr ref_subscriber_ = nullptr;

--- a/templates/ros2_control/controller/test_dummy_chainable_controller.cpp
+++ b/templates/ros2_control/controller/test_dummy_chainable_controller.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Stogl Robotics Consulting UG (haftungsbeschränkt) (template)
+// Copyright (c) 2023, Stogl Robotics Consulting UG (haftungsbeschränkt) (template)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,31 +20,34 @@
 #include <utility>
 #include <vector>
 
-using dummy_package_namespace::CMD_MY_ITFS;
+using dummy_package_namespace::NR_CMD_ITFS;
+using dummy_package_namespace::NR_REF_ITFS;
+using dummy_package_namespace::NR_STATE_ITFS;
+
 using dummy_package_namespace::control_mode_type;
-using dummy_package_namespace::STATE_MY_ITFS;
+
 
 class DummyClassNameTest : public DummyClassNameFixture<TestableDummyClassName>
 {
 };
 
-TEST_F(DummyClassNameTest, all_parameters_set_configure_success)
+TEST_F(DummyClassNameTest, when_controller_is_configured_expect_all_parameters_set)
 {
   SetUpController();
 
-  ASSERT_TRUE(controller_->params_.joints.empty());
-  ASSERT_TRUE(controller_->params_.state_joints.empty());
+  ASSERT_TRUE(controller_->params_.command_joint_names.empty());
+  ASSERT_TRUE(controller_->params_.state_joint_names.empty());
   ASSERT_TRUE(controller_->params_.interface_name.empty());
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  ASSERT_THAT(controller_->params_.joints, testing::ElementsAreArray(joint_names_));
-  ASSERT_TRUE(controller_->params_.state_joints.empty());
-  ASSERT_THAT(controller_->state_joints_, testing::ElementsAreArray(joint_names_));
+  ASSERT_THAT(controller_->params_.command_joint_names, testing::ElementsAreArray(command_joint_names_));
+  ASSERT_TRUE(controller_->params_.state_joint_names.empty());
+  ASSERT_THAT(controller_->state_joint_names_, testing::ElementsAreArray(command_joint_names_));
   ASSERT_EQ(controller_->params_.interface_name, interface_name_);
 }
 
-TEST_F(DummyClassNameTest, check_exported_intefaces)
+TEST_F(DummyClassNameTest, when_controller_configured_expect_properly_exported_interfaces)
 {
   SetUpController();
 
@@ -53,29 +56,29 @@ TEST_F(DummyClassNameTest, check_exported_intefaces)
   auto command_intefaces = controller_->command_interface_configuration();
   ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());
   for (size_t i = 0; i < command_intefaces.names.size(); ++i) {
-    EXPECT_EQ(command_intefaces.names[i], joint_names_[i] + "/" + interface_name_);
+    EXPECT_EQ(command_intefaces.names[i], command_joint_names_[i] + "/" + interface_name_);
   }
 
   auto state_intefaces = controller_->state_interface_configuration();
   ASSERT_EQ(state_intefaces.names.size(), joint_state_values_.size());
   for (size_t i = 0; i < state_intefaces.names.size(); ++i) {
-    EXPECT_EQ(state_intefaces.names[i], joint_names_[i] + "/" + interface_name_);
+    EXPECT_EQ(state_intefaces.names[i], command_joint_names_[i] + "/" + interface_name_);
   }
 
   // check ref itfs
   auto reference_interfaces = controller_->export_reference_interfaces();
-  ASSERT_EQ(reference_interfaces.size(), joint_names_.size());
-  for (size_t i = 0; i < joint_names_.size(); ++i) {
-    const std::string ref_itf_name = std::string(controller_->get_node()->get_name()) + "/" +
-                                     joint_names_[i] + "/" + interface_name_;
+  ASSERT_EQ(reference_interfaces.size(), NR_REF_ITFS);
+  for (size_t i = 0; i < reference_interface_names.size(); ++i) {
+    const std::string ref_itf_name = std::string(controller_->get_node()->get_name()) +
+                                   std::string("/") + reference_interface_names[i];
     EXPECT_EQ(reference_interfaces[i].get_name(), ref_itf_name);
     EXPECT_EQ(reference_interfaces[i].get_prefix_name(), controller_->get_node()->get_name());
     EXPECT_EQ(
-      reference_interfaces[i].get_interface_name(), joint_names_[i] + "/" + interface_name_);
+      reference_interfaces[i].get_interface_name(), reference_interface_names[i]);
   }
 }
 
-TEST_F(DummyClassNameTest, activate_success)
+TEST_F(DummyClassNameTest, when_controller_is_activated_expect_reference_reset)
 {
   SetUpController();
 
@@ -84,24 +87,24 @@ TEST_F(DummyClassNameTest, activate_success)
 
   // check that the message is reset
   auto msg = controller_->input_ref_.readFromNonRT();
-  EXPECT_EQ((*msg)->displacements.size(), joint_names_.size());
+  EXPECT_EQ((*msg)->displacements.size(), command_joint_names_.size());
   for (const auto & cmd : (*msg)->displacements) {
     EXPECT_TRUE(std::isnan(cmd));
   }
-  EXPECT_EQ((*msg)->velocities.size(), joint_names_.size());
+  EXPECT_EQ((*msg)->velocities.size(), command_joint_names_.size());
   for (const auto & cmd : (*msg)->velocities) {
     EXPECT_TRUE(std::isnan(cmd));
   }
 
   ASSERT_TRUE(std::isnan((*msg)->duration));
 
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_names_.size());
+  EXPECT_EQ(controller_->reference_interfaces_.size(), command_joint_names_.size());
   for (const auto & interface : controller_->reference_interfaces_) {
     EXPECT_TRUE(std::isnan(interface));
   }
 }
 
-TEST_F(DummyClassNameTest, update_success)
+TEST_F(DummyClassNameTest, when_controller_active_and_update_called_expect_success)
 {
   SetUpController();
 
@@ -109,11 +112,11 @@ TEST_F(DummyClassNameTest, update_success)
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
   ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
 }
 
-TEST_F(DummyClassNameTest, deactivate_success)
+TEST_F(DummyClassNameTest, when_active_controller_is_deactivated_expect_success)
 {
   SetUpController();
 
@@ -122,24 +125,41 @@ TEST_F(DummyClassNameTest, deactivate_success)
   ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
 }
 
-TEST_F(DummyClassNameTest, reactivate_success)
+TEST_F(DummyClassNameTest, when_controller_is_reactivated_expect_cmd_itfs_not_set_and_update_success)
 {
   SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->command_interfaces_[CMD_MY_ITFS].get_value(), 101.101);
+  ASSERT_EQ(controller_->command_interfaces_[NR_CMD_ITFS].get_value(), 101.101);
   ASSERT_EQ(controller_->on_deactivate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_TRUE(std::isnan(controller_->command_interfaces_[CMD_MY_ITFS].get_value()));
+  ASSERT_TRUE(std::isnan(controller_->command_interfaces_[NR_CMD_ITFS].get_value()));
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_TRUE(std::isnan(controller_->command_interfaces_[CMD_MY_ITFS].get_value()));
+  ASSERT_TRUE(std::isnan(controller_->command_interfaces_[NR_CMD_ITFS].get_value()));
 
   ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
 }
 
-TEST_F(DummyClassNameTest, test_setting_slow_mode_service)
+// when update is called expect the previously set reference before calling update,
+// inside the controller state message
+TEST_F(DummyClassNameTest, when_update_is_called_expect_status_message)
+{
+  SetUpController();
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+
+  controller_->reference_interfaces_[0] = 1.5;
+
+  ControllerStateMsg msg;
+  subscribe_to_controller_status_execute_update_and_get_messages(msg);
+
+  EXPECT_EQ(msg.set_point, 1.5);
+}
+
+TEST_F(DummyClassNameTest, when_controller_is_configured_and_activated_properly_expect_correct_setting_of_mode_service)
 {
   SetUpController();
 
@@ -165,206 +185,269 @@ TEST_F(DummyClassNameTest, test_setting_slow_mode_service)
   ASSERT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
 }
 
-TEST_F(DummyClassNameTest, test_update_logic_fast)
+// reference_interfaces and command_interfaces values depend on the reference_msg,
+// the below test shows two cases when reference_msg is not received and when it is received.
+TEST_F(
+  DummyClassNameTest,
+  when_reference_msg_received_expect_updated_commands_and_status_message)
 {
   SetUpController();
+
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
-
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  controller_->set_chained_mode(false);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_FALSE(controller_->is_in_chained_mode());
-
-  // set command statically
-  static constexpr double TEST_DISPLACEMENT = 23.24;
-  std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();
-  msg->joint_names = joint_names_;
-  msg->displacements.resize(joint_names_.size(), TEST_DISPLACEMENT);
-  msg->velocities.resize(joint_names_.size(), std::numeric_limits<double>::quiet_NaN());
-  msg->duration = std::numeric_limits<double>::quiet_NaN();
-  controller_->input_ref_.writeFromNonRT(msg);
-
-  ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
-    controller_interface::return_type::OK);
-
-  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
-  EXPECT_EQ(joint_command_values_[STATE_MY_ITFS], TEST_DISPLACEMENT);
-  EXPECT_TRUE(std::isnan((*(controller_->input_ref_.readFromRT()))->displacements[0]));
-  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_names_.size());
-  for (const auto & interface : controller_->reference_interfaces_) {
-    EXPECT_TRUE(std::isnan(interface));
-  }
-}
-
-TEST_F(DummyClassNameTest, test_update_logic_slow)
-{
-  SetUpController();
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
-
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  controller_->set_chained_mode(false);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_FALSE(controller_->is_in_chained_mode());
-
-  // set command statically
-  static constexpr double TEST_DISPLACEMENT = 23.24;
-  std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();
-  // When slow mode is enabled command ends up being half of the value
-  msg->joint_names = joint_names_;
-  msg->displacements.resize(joint_names_.size(), TEST_DISPLACEMENT);
-  msg->velocities.resize(joint_names_.size(), std::numeric_limits<double>::quiet_NaN());
-  msg->duration = std::numeric_limits<double>::quiet_NaN();
-  controller_->input_ref_.writeFromNonRT(msg);
-  controller_->control_mode_.writeFromNonRT(control_mode_type::SLOW);
-
-  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::SLOW);
-  ASSERT_EQ((*(controller_->input_ref_.readFromRT()))->displacements[0], TEST_DISPLACEMENT);
-  ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
-    controller_interface::return_type::OK);
-
-  EXPECT_EQ(joint_command_values_[STATE_MY_ITFS], TEST_DISPLACEMENT / 2);
-  EXPECT_TRUE(std::isnan((*(controller_->input_ref_.readFromRT()))->displacements[0]));
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_names_.size());
-  for (const auto & interface : controller_->reference_interfaces_) {
-    EXPECT_TRUE(std::isnan(interface));
-  }
-}
-
-TEST_F(DummyClassNameTest, test_update_logic_chainable_fast)
-{
-  SetUpController();
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
-
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_TRUE(controller_->is_in_chained_mode());
-
-  // set command statically
-  static constexpr double TEST_DISPLACEMENT = 23.24;
-  std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();
-  msg->joint_names = joint_names_;
-  msg->displacements.resize(joint_names_.size(), TEST_DISPLACEMENT);
-  msg->velocities.resize(joint_names_.size(), std::numeric_limits<double>::quiet_NaN());
-  msg->duration = std::numeric_limits<double>::quiet_NaN();
-  controller_->input_ref_.writeFromNonRT(msg);
-  // this is input source in chained mode
-  controller_->reference_interfaces_[STATE_MY_ITFS] = TEST_DISPLACEMENT * 2;
-
-  ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
-    controller_interface::return_type::OK);
-
-  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
-  // reference_interfaces is directly applied
-  EXPECT_EQ(joint_command_values_[STATE_MY_ITFS], TEST_DISPLACEMENT * 2);
-  // message is not touched in chained mode
-  EXPECT_EQ((*(controller_->input_ref_.readFromRT()))->displacements[0], TEST_DISPLACEMENT);
-  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_names_.size());
-  for (const auto & interface : controller_->reference_interfaces_) {
-    EXPECT_TRUE(std::isnan(interface));
-  }
-}
-
-TEST_F(DummyClassNameTest, test_update_logic_chainable_slow)
-{
-  SetUpController();
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(controller_->get_node()->get_node_base_interface());
-  executor.add_node(service_caller_node_->get_node_base_interface());
-
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  controller_->set_chained_mode(true);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_TRUE(controller_->is_in_chained_mode());
-
-  // set command statically
-  static constexpr double TEST_DISPLACEMENT = 23.24;
-  std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();
-  // When slow mode is enabled command ends up being half of the value
-  msg->joint_names = joint_names_;
-  msg->displacements.resize(joint_names_.size(), TEST_DISPLACEMENT);
-  msg->velocities.resize(joint_names_.size(), std::numeric_limits<double>::quiet_NaN());
-  msg->duration = std::numeric_limits<double>::quiet_NaN();
-  controller_->input_ref_.writeFromNonRT(msg);
-  controller_->control_mode_.writeFromNonRT(control_mode_type::SLOW);
-  // this is input source in chained mode
-  controller_->reference_interfaces_[STATE_MY_ITFS] = TEST_DISPLACEMENT * 4;
-
-  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::SLOW);
-  ASSERT_EQ((*(controller_->input_ref_.readFromRT()))->displacements[0], TEST_DISPLACEMENT);
-  ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
-    controller_interface::return_type::OK);
-
-  // reference_interfaces is directly applied
-  EXPECT_EQ(joint_command_values_[STATE_MY_ITFS], TEST_DISPLACEMENT * 2);
-  // message is not touched in chained mode
-  EXPECT_EQ((*(controller_->input_ref_.readFromRT()))->displacements[0], TEST_DISPLACEMENT);
-  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_names_.size());
-  for (const auto & interface : controller_->reference_interfaces_) {
-    EXPECT_TRUE(std::isnan(interface));
-  }
-}
-
-TEST_F(DummyClassNameTest, publish_status_success)
-{
-  SetUpController();
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
   ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-
+  // no reference_msg sent
   ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
+    controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
-
   ControllerStateMsg msg;
-  subscribe_and_get_messages(msg);
+  subscribe_to_controller_status_execute_update_and_get_messages(msg);
 
   ASSERT_EQ(msg.set_point, 101.101);
-}
+  joint_command_values_[0] = TEST_DISPLACEMENT;
 
-TEST_F(DummyClassNameTest, receive_message_and_publish_updated_status)
-{
-  SetUpController();
-  rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(controller_->get_node()->get_node_base_interface());
-
-  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
-  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
-
-  ASSERT_EQ(
-    controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
-    controller_interface::return_type::OK);
-
-  ControllerStateMsg msg;
-  subscribe_and_get_messages(msg);
-
-  ASSERT_EQ(msg.set_point, 101.101);
-
-  publish_commands();
+  // reference_callback() is implicitly called when publish_commands() is called
+  // reference_msg is published with provided time stamp when publish_commands( time_stamp)
+  // is called
+  publish_commands(controller_->get_node()->now());
   ASSERT_TRUE(controller_->wait_for_commands(executor));
 
   ASSERT_EQ(
+    controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // EXPLAIN WHY THE BELOW EQUALITY IS VALID
+  // depends on how command_interface values are set inside update methods
+  EXPECT_EQ(joint_command_values_[0], 0.45);
+
+  subscribe_to_controller_status_execute_update_and_get_messages(msg);
+
+  ASSERT_EQ(msg.set_point, 0.45);
+
+}
+
+TEST_F(DummyClassNameTest, when_controller_mode_set_fast_expect_update_logic_for_fast_mode)
+{
+  SetUpController();
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
+  executor.add_node(service_caller_node_->get_node_base_interface());
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  controller_->set_chained_mode(false);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_FALSE(controller_->is_in_chained_mode());
+
+  // set command statically
+  static constexpr double TEST_DISPLACEMENT = 23.24;
+  std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();
+  msg->joint_names = command_joint_names_;
+  msg->displacements.resize(command_joint_names_.size(), TEST_DISPLACEMENT);
+  msg->velocities.resize(command_joint_names_.size(), std::numeric_limits<double>::quiet_NaN());
+  msg->duration = std::numeric_limits<double>::quiet_NaN();
+  controller_->input_ref_.writeFromNonRT(msg);
+
+  ASSERT_EQ(
+    controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
+  EXPECT_EQ(joint_command_values_[NR_STATE_ITFS], TEST_DISPLACEMENT);
+  EXPECT_TRUE(std::isnan((*(controller_->input_ref_.readFromRT()))->displacements[0]));
+  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
+  EXPECT_EQ(controller_->reference_interfaces_.size(), command_joint_names_.size());
+  for (const auto & interface : controller_->reference_interfaces_) {
+    EXPECT_TRUE(std::isnan(interface));
+  }
+}
+
+TEST_F(DummyClassNameTest, when_controller_mode_set_slow_expect_update_logic_for_slow_mode)
+{
+  SetUpController();
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
+  executor.add_node(service_caller_node_->get_node_base_interface());
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  controller_->set_chained_mode(false);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_FALSE(controller_->is_in_chained_mode());
+
+  // set command statically
+  static constexpr double TEST_DISPLACEMENT = 23.24;
+  std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();
+  // When slow mode is enabled command ends up being half of the value
+  msg->joint_names = command_joint_names_;
+  msg->displacements.resize(command_joint_names_.size(), TEST_DISPLACEMENT);
+  msg->velocities.resize(command_joint_names_.size(), std::numeric_limits<double>::quiet_NaN());
+  msg->duration = std::numeric_limits<double>::quiet_NaN();
+  controller_->input_ref_.writeFromNonRT(msg);
+  controller_->control_mode_.writeFromNonRT(control_mode_type::SLOW);
+
+  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::SLOW);
+  ASSERT_EQ((*(controller_->input_ref_.readFromRT()))->displacements[0], TEST_DISPLACEMENT);
+  ASSERT_EQ(
     controller_->update(rclcpp::Time(0), rclcpp::Duration::from_seconds(0.01)),
     controller_interface::return_type::OK);
 
-  EXPECT_EQ(joint_command_values_[CMD_MY_ITFS], 0.45);
-
-  subscribe_and_get_messages(msg);
-
-  ASSERT_EQ(msg.set_point, 0.45);
+  EXPECT_EQ(joint_command_values_[NR_STATE_ITFS], TEST_DISPLACEMENT / 2);
+  EXPECT_TRUE(std::isnan((*(controller_->input_ref_.readFromRT()))->displacements[0]));
+  EXPECT_EQ(controller_->reference_interfaces_.size(), command_joint_names_.size());
+  for (const auto & interface : controller_->reference_interfaces_) {
+    EXPECT_TRUE(std::isnan(interface));
+  }
 }
+
+TEST_F(DummyClassNameTest, when_controller_mode_set_chainable_and_fast_expect_receiving_commands_from_reference_interfaces_directly_with_fast_mode_logic_effect)
+{
+  SetUpController();
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
+  executor.add_node(service_caller_node_->get_node_base_interface());
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  controller_->set_chained_mode(true);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(controller_->is_in_chained_mode());
+
+    for (const auto & interface : controller_->reference_interfaces_)
+  {
+    EXPECT_TRUE(std::isnan(interface));
+  }
+  // set mode to fast
+  controller_->control_mode_.writeFromNonRT(control_mode_type::FAST);
+  // this is input source in chained mode
+  controller_->reference_interfaces_[NR_STATE_ITFS] = TEST_DISPLACEMENT * 2;
+
+    // reference_callback() is implicitly called when publish_commands() is called
+  // reference_msg is published with provided time stamp when publish_commands( time_stamp)
+  // is called
+  publish_commands(controller_->get_node()->now(),TEST_DISPLACEMENT);
+
+  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
+  ASSERT_EQ((*(controller_->input_ref_.readFromRT()))->displacements[0], TEST_DISPLACEMENT);
+
+  ASSERT_EQ(
+    controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
+  // reference_interfaces is directly applied
+  EXPECT_EQ(joint_command_values_[NR_STATE_ITFS], TEST_DISPLACEMENT * 2);
+  // message is not touched in chained mode
+  EXPECT_EQ((*(controller_->input_ref_.readFromRT()))->displacements[0], TEST_DISPLACEMENT);
+  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::FAST);
+  EXPECT_EQ(controller_->reference_interfaces_.size(), command_joint_names_.size());
+  for (const auto & interface : controller_->reference_interfaces_) {
+    EXPECT_TRUE(std::isnan(interface));
+  }
+}
+
+TEST_F(DummyClassNameTest, when_controller_mode_set_chainable_and_slow_expect_receiving_commands_from_reference_interfaces_directly_with_slow_mode_logic_effect)
+{
+  SetUpController();
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
+  executor.add_node(service_caller_node_->get_node_base_interface());
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  controller_->set_chained_mode(true);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_TRUE(controller_->is_in_chained_mode());
+
+  for (const auto & interface : controller_->reference_interfaces_)
+  {
+    EXPECT_TRUE(std::isnan(interface));
+  }
+
+  // set mode to slow
+  controller_->control_mode_.writeFromNonRT(control_mode_type::SLOW);
+  // this is input source in chained mode
+  controller_->reference_interfaces_[NR_STATE_ITFS] = TEST_DISPLACEMENT * 4;
+  // reference_callback() is implicitly called when publish_commands() is called
+  // reference_msg is published with provided time stamp when publish_commands( time_stamp)
+  // is called
+  publish_commands(controller_->get_node()->now(),TEST_DISPLACEMENT);
+  ASSERT_TRUE(controller_->wait_for_commands(executor));
+
+
+  EXPECT_EQ(*(controller_->control_mode_.readFromRT()), control_mode_type::SLOW);
+  ASSERT_EQ((*(controller_->input_ref_.readFromRT()))->displacements[0], TEST_DISPLACEMENT);
+  ASSERT_EQ(
+    controller_->update(controller_->get_node()->now(), rclcpp::Duration::from_seconds(0.01)),
+    controller_interface::return_type::OK);
+
+  // reference_interfaces is directly applied / expected slow mode logic effect
+  EXPECT_EQ(joint_command_values_[NR_STATE_ITFS], TEST_DISPLACEMENT * 2);
+  // message is not touched in chained mode
+  EXPECT_EQ((*(controller_->input_ref_.readFromRT()))->displacements[0], TEST_DISPLACEMENT);
+  EXPECT_EQ(controller_->reference_interfaces_.size(), joint_names_.size());
+  for (const auto & interface : controller_->reference_interfaces_) {
+    EXPECT_TRUE(std::isnan(interface));
+  }
+}
+
+// when time stamp is zero expect that time stamp is set to current time stamp
+TEST_F(
+  DummyClassNameTest,
+  when_reference_msg_has_timestamp_zero_expect_reference_set_and_timestamp_set_to_current_time)
+{
+  SetUpController();
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+
+  auto reference = controller_->input_ref_.readFromNonRT();
+  auto old_timestamp = (*reference)->header.stamp;
+  EXPECT_TRUE(std::isnan((*reference)->displacements));
+
+
+  // reference_callback() is implicitly called when publish_commands() is called
+  // reference_msg is published with provided time stamp when publish_commands( time_stamp)
+  // is called
+  publish_commands(controller_->get_node()->now());
+
+  ASSERT_TRUE(controller_->wait_for_commands(executor));
+  ASSERT_EQ(old_timestamp.sec, (*(controller_->input_ref_.readFromNonRT()))->header.stamp.sec);
+  EXPECT_FALSE(std::isnan((*(controller_->input_ref_.readFromNonRT()))->displacements));
+  EXPECT_EQ((*(controller_->input_ref_.readFromNonRT()))->displacements, 0.45);
+
+  EXPECT_NE((*(controller_->input_ref_.readFromNonRT()))->header.stamp.sec, 0.0);
+}
+
+// when the reference_msg has valid timestamp then the timeout check in reference_callback()
+// shall pass and reference_msg is not reset
+TEST_F(DummyClassNameTest, when_message_has_valid_timestamp_expect_reference_set)
+{
+  SetUpController();
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(controller_->get_node()->get_node_base_interface());
+
+  ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
+  ASSERT_EQ(controller_->on_activate(rclcpp_lifecycle::State()), NODE_SUCCESS);
+
+  auto reference = controller_->input_ref_.readFromNonRT();
+  EXPECT_TRUE(std::isnan((*reference)->displacements));
+
+  // reference_callback() is implicitly called when publish_commands() is called
+  // reference_msg is published with provided time stamp when publish_commands( time_stamp)
+  // is called
+  publish_commands(controller_->get_node()->now());
+
+  ASSERT_TRUE(controller_->wait_for_commands(executor));
+  EXPECT_FALSE(std::isnan((*(controller_->input_ref_.readFromNonRT()))->displacements));
+  EXPECT_EQ((*(controller_->input_ref_.readFromNonRT()))->displacements, 0.45);
+
+}
+
+
+
+
 
 int main(int argc, char ** argv)
 {

--- a/templates/ros2_control/controller/test_dummy_controller_preceeding.cpp
+++ b/templates/ros2_control/controller/test_dummy_controller_preceeding.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Stogl Robotics Consulting UG (haftungsbeschränkt) (template)
+// Copyright (c) 2023, Stogl Robotics Consulting UG (haftungsbeschränkt) (template)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,31 +20,33 @@
 #include <utility>
 #include <vector>
 
-using dummy_package_namespace::CMD_MY_ITFS;
+using dummy_package_namespace::NR_CMD_ITFS;
+using dummy_package_namespace::NR_REF_ITFS;
+using dummy_package_namespace::NR_STATE_ITFS;
 using dummy_package_namespace::control_mode_type;
-using dummy_package_namespace::STATE_MY_ITFS;
+
 
 class DummyClassNameTest : public DummyClassNameFixture<TestableDummyClassName>
 {
 };
 
-TEST_F(DummyClassNameTest, all_parameters_set_configure_success)
+TEST_F(DummyClassNameTest, when_controller_is_configured_expect_all_parameters_set)
 {
   SetUpController();
 
-  ASSERT_TRUE(controller_->params_.joints.empty());
-  ASSERT_TRUE(controller_->params_.state_joints.empty());
+  ASSERT_TRUE(controller_->params_.command_joint_names.empty());
+  ASSERT_TRUE(controller_->params_.state_joint_names.empty());
   ASSERT_TRUE(controller_->params_.interface_name.empty());
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), NODE_SUCCESS);
 
-  ASSERT_THAT(controller_->params_.joints, testing::ElementsAreArray(joint_names_));
-  ASSERT_THAT(controller_->params_.state_joints, testing::ElementsAreArray(state_joint_names_));
-  ASSERT_THAT(controller_->state_joints_, testing::ElementsAreArray(state_joint_names_));
+  ASSERT_THAT(controller_->params_.command_joint_names, testing::ElementsAreArray(command_joint_names_));
+  ASSERT_THAT(controller_->params_.state_joint_names, testing::ElementsAreArray(state_joint_names_));
+  ASSERT_THAT(controller_->state_joint_names_, testing::ElementsAreArray(state_joint_names_));
   ASSERT_EQ(controller_->params_.interface_name, interface_name_);
 }
 
-TEST_F(DummyClassNameTest, check_exported_intefaces)
+TEST_F(DummyClassNameTest, when_controller_configured_expect_properly_exported_interfaces)
 {
   SetUpController();
 
@@ -53,7 +55,7 @@ TEST_F(DummyClassNameTest, check_exported_intefaces)
   auto command_intefaces = controller_->command_interface_configuration();
   ASSERT_EQ(command_intefaces.names.size(), joint_command_values_.size());
   for (size_t i = 0; i < command_intefaces.names.size(); ++i) {
-    EXPECT_EQ(command_intefaces.names[i], joint_names_[i] + "/" + interface_name_);
+    EXPECT_EQ(command_intefaces.names[i], command_joint_names_[i] + "/" + interface_name_);
   }
 
   auto state_intefaces = controller_->state_interface_configuration();

--- a/templates/ros2_control/controller/test_load_dummy_controller.cpp
+++ b/templates/ros2_control/controller/test_load_dummy_controller.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Stogl Robotics Consulting UG (haftungsbeschränkt) (template)
+// Copyright (c) 2023, Stogl Robotics Consulting UG (haftungsbeschränkt) (template)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
created a ros2_controller package from this template and all tests pass, tests specific to ref_timeout are not included as they are being addressed on the ref_timeout branch