### PR TITLE
Ros domain zero

### DIFF
--- a/templates/.ros_team_ws_rc
+++ b/templates/.ros_team_ws_rc
@@ -12,13 +12,13 @@ TEAM_REPOSITORY_SERVER="https://github.com"
 TEAM_PRIVATE_CONFIG_PATH=""
 
 # set this to the location of RosTeamWorkspace
-source <PATH TO ros_team_workspace>/setup.bash
+source <PATH TO ros_team_workspace >/setup.bash
 
 # User specific setup / variables
 
 #export CYCLONEDDS_URI='<CycloneDDS><Domain><General><NetworkInterfaceAddress>ADD_HERE_INTERFACE_NAME</NetworkInterfaceAddress></General></Domain></CycloneDDS>'
 
-export ROS_DOMAIN_ID=42  # Set your Domain ID if you are in a network with multiple computers
+export ROS_DOMAIN_ID=0 # Set your Domain ID if you are in a network with multiple computers
 
 # Logging setup
 # export RCUTILS_LOGGING_CONFIG_FILE="/home/deniss/workspace/ros2_logging_config"

--- a/templates/.ros_team_ws_rc
+++ b/templates/.ros_team_ws_rc
@@ -12,7 +12,7 @@ TEAM_REPOSITORY_SERVER="https://github.com"
 TEAM_PRIVATE_CONFIG_PATH=""
 
 # set this to the location of RosTeamWorkspace
-source <PATH TO ros_team_workspace >/setup.bash
+source <PATH TO ros_team_workspace>/setup.bash
 
 # User specific setup / variables
 

--- a/templates/docker/ros_team_ws_rc_docker
+++ b/templates/docker/ros_team_ws_rc_docker
@@ -20,7 +20,7 @@ source /opt/RosTeamWS/ros_ws_ROS_DUMMY_VERSION/src/ros_team_workspace/setup.bash
 
 #export CYCLONEDDS_URI='<CycloneDDS><Domain><General><NetworkInterfaceAddress>ADD_HERE_INTERFACE_NAME</NetworkInterfaceAddress></General></Domain></CycloneDDS>'
 
-export ROS_DOMAIN_ID=42  # Set your Domain ID if you are in a network with multiple computers
+export ROS_DOMAIN_ID=0 # Set your Domain ID if you are in a network with multiple computers
 
 # Logging setup
 # export RCUTILS_LOGGING_CONFIG_FILE="/home/deniss/workspace/ros2_logging_config"


### PR DESCRIPTION
Set the ROS_DOMAIN=0 since this is the default. If users want to set a specific domain themselves, they can do so. Would set to default because setting it to 42 makes more harm than good, since communication with different devices on network is not possible by default. Users probably do not expect this behavior. And could lose time to figure out what's going on.