### PR TITLE
Bump for Iron: setup-ros -> 0.6.2 action-ros-ci -> 0.3.2

### DIFF
--- a/templates/package/CI-github_ci-coverage-build.yml
+++ b/templates/package/CI-github_ci-coverage-build.yml
@@ -16,11 +16,11 @@ jobs:
     env:
       ROS_DISTRO: $ros_distro$
     steps:
-      - uses: ros-tooling/setup-ros@0.3.4
+      - uses: ros-tooling/setup-ros@0.6.2
         with:
           required-ros-distributions: ${{ env.ROS_DISTRO }}
       - uses: actions/checkout@v3
-      - uses: ros-tooling/action-ros-ci@0.2.6
+      - uses: ros-tooling/action-ros-ci@0.3.2
         with:
           target-ros2-distro: ${{ env.ROS_DISTRO }}
           import-token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/package/CI-github_ci-ros-lint.yml
+++ b/templates/package/CI-github_ci-ros-lint.yml
@@ -12,7 +12,7 @@ jobs:
           linter: [cppcheck, copyright, lint_cmake]
     steps:
     - uses: actions/checkout@v3
-    - uses: ros-tooling/setup-ros@v0.2
+    - uses: ros-tooling/setup-ros@v0.6
     - uses: ros-tooling/action-ros-lint@v0.1
       with:
         distribution: $ros_distro$
@@ -29,7 +29,7 @@ jobs:
           linter: [cpplint]
     steps:
     - uses: actions/checkout@v3
-    - uses: ros-tooling/setup-ros@v0.2
+    - uses: ros-tooling/setup-ros@v0.6
     - uses: ros-tooling/action-ros-lint@v0.1
       with:
         distribution: $ros_distro$

--- a/templates/package/CI-github_reusable-ros-tooling-source-build.yml
+++ b/templates/package/CI-github_reusable-ros-tooling-source-build.yml
@@ -26,13 +26,13 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: ros-tooling/setup-ros@0.3.4
+      - uses: ros-tooling/setup-ros@0.6.2
         with:
           required-ros-distributions: ${{ inputs.ros_distro }}
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-      - uses: ros-tooling/action-ros-ci@0.2.6
+      - uses: ros-tooling/action-ros-ci@0.3.2
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}
           # build all packages listed in the meta package


### PR DESCRIPTION
- https://github.com/ros-tooling/setup-ros/releases/tag/0.6.2
- https://github.com/ros-tooling/action-ros-ci/releases/tag/0.3.2
  - 0.3.1 added Iron support
  - 0.3.2 added ref arg for scheduled jobs