### PR TITLE
Fixing gid setup using uid instead of gid

### DIFF
--- a/templates/docker/nvidia.dockerfile
+++ b/templates/docker/nvidia.dockerfile
@@ -63,7 +63,7 @@ COPY ros_team_ws_rc_docker ${home}/.ros_team_ws_rc
 # the passwd delete is needed to update /etc/shadow otherwise user cannot use sudo
 RUN mkdir -p ${home} && \
   echo "${user}:x:${uid}:${gid}:${user},,,:${home}:/bin/bash" >> /etc/passwd && \
-  echo "${user}:x:${uid}:" >> /etc/group && \
+  echo "${user}:x:${gid}:" >> /etc/group && \
   echo "${user} ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/${user}" && \
   chmod 0440 "/etc/sudoers.d/${user}" && \
   usermod -aG sudo ${user} && \

--- a/templates/docker/standard.dockerfile
+++ b/templates/docker/standard.dockerfile
@@ -60,7 +60,7 @@ COPY ros_team_ws_rc_docker ${home}/.ros_team_ws_rc
 # the passwd delete is needed to update /etc/shadow otherwise user cannot use sudo
 RUN mkdir -p ${home} && \
   echo "${user}:x:${uid}:${gid}:${user},,,:${home}:/bin/bash" >> /etc/passwd && \
-  echo "${user}:x:${uid}:" >> /etc/group && \
+  echo "${user}:x:${gid}:" >> /etc/group && \
   echo "${user} ALL=(ALL) NOPASSWD: ALL" > "/etc/sudoers.d/${user}" && \
   chmod 0440 "/etc/sudoers.d/${user}" && \
   usermod -aG sudo ${user} && \


### PR DESCRIPTION
For a setup in which uid != gid   (1001:1002) after a docker container was created this error would occur

```
[docker]>workspaces$ rtw_switch_to_docker
Starting container instance: ros-team-ws_ubuntu_22_04_nvidia__docker-instance 
non-network local connections being added to access control list
ros-team-ws_ubuntu_22_04_nvidia__docker-instance
Connecting to container instance as user: ros-team-ws_ubuntu_22_04_nvidia__docker-instance
groups: cannot find name for group ID 1002
```

this comes from the uid being used instead of the gid when filling /etc/group

after the fix no more error.

