### PR TITLE
Add guidelines on open source contributions

### DIFF
--- a/docs/guidelines/open_source_commits.rst
+++ b/docs/guidelines/open_source_commits.rst
@@ -3,25 +3,17 @@ Guidelines on contributing to open-source projects
 =======================
 .. _guidelines-development:
 
-This documents proposes development guidelines on how to make contributions to open-source projects in a structured manner. 
+This documents proposes development guidelines on how to make contributions to open-source projects in a structured manner. When you find a new issue or want to solve an existing issue in an open source project, you can perform the following steps to increase the chances of making your contribution useful and appreciated.
 
 **NOTE**: All the proposal here are the results of authors' personal experiences. Saying that, if you have any idea to make them better you are very welcome to create a PR.
 
-Steps to follow
-=========
+#. First, try and fix the changes locally in your own branch. Usually, you do this in a repository which is forked from the main open-source project.
 
-1. Try and fix the changes locally in your own fork
+#. Once you've found a good solution, commit and push to your own feature branch. Be aware that you only fix the relevant issue in this feature branch, don't make more changes than is necessary.
 
-2. Commit and push to your own feature branch
+#. Go to the upstream branch of your forked repository, and create a new feature branch. 
 
-3. Go to the upstream branch(of the main project, not just the fork)
+#. In this feature branch, apply the changes you made in your previous branch with its commit hash(using cherry-pick) and push it.
 
-4. Create a new feature branch from the upstream branch
+#. Open a pull request on the upstream branch of the main repository for your feature branch. Make sure you adhere to the project's guidelines on how to write the pull request.
 
-5. Apply your changes(using cherry-pick) using your own commit hash
-
-6. Push to your own repository branch
-
-7 Open a pull request on the upstream repository
-
-**WORK-IN-PROGRESS, MORE CONTENT AND MORE IMPROVEMENTS TO BE ADDED SOON**

--- a/docs/guidelines/open_source_commits.rst
+++ b/docs/guidelines/open_source_commits.rst
@@ -1,0 +1,27 @@
+=======================
+Guidelines on contributing to open-source projects
+=======================
+.. _guidelines-development:
+
+This documents proposes development guidelines on how to make contributions to open-source projects in a structured manner. 
+
+**NOTE**: All the proposal here are the results of authors' personal experiences. Saying that, if you have any idea to make them better you are very welcome to create a PR.
+
+Steps to follow
+=========
+
+1. Try and fix the changes locally in your own fork
+
+2. Commit and push to your own feature branch
+
+3. Go to the upstream branch(of the main project, not just the fork)
+
+4. Create a new feature branch from the upstream branch
+
+5. Apply your changes(using cherry-pick) using your own commit hash
+
+6. Push to your own repository branch
+
+7 Open a pull request on the upstream repository
+
+**WORK-IN-PROGRESS, MORE CONTENT AND MORE IMPROVEMENTS TO BE ADDED SOON**


### PR DESCRIPTION
This updates the documentation with a new page which contains guidelines on how to do a proper commit to open-source projects in general. No other changes or tests were made.