### PR TITLE
Add separate script for setting up formatting for a repository.

### DIFF
--- a/scripts/_Team_Defines.bash
+++ b/scripts/_Team_Defines.bash
@@ -57,6 +57,8 @@ alias setup-repository=$RosTeamWS_FRAMEWORK_SCRIPTS_PATH/setup-repository.bash
 
 alias setup-repository-ci=$RosTeamWS_FRAMEWORK_SCRIPTS_PATH/setup-repository-ci.bash
 
+alias setup-formatting=$RosTeamWS_FRAMEWORK_SCRIPTS_PATH/setup-formatting.bash
+
 alias setup-ros-workspace=$RosTeamWS_FRAMEWORK_SCRIPTS_PATH/setup-ros-workspace.bash
 
 setup-ros-workspace () {

--- a/scripts/setup-formatting.bash
+++ b/scripts/setup-formatting.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright 2023 Stogl Robotics Consulting UG (haftungsbeschränkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Author: Dr. Denis Stogl
+
+
+usage='setup-formatting.bash'
+
+# Load Framework defines
+script_own_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+source $script_own_dir/../setup.bash
+
+# Setting up formatting
+cp -n ${PACKAGE_TEMPLATES}/.clang-format .
+cp -n ${PACKAGE_TEMPLATES}/.pre-commit-config.yaml .
+touch ".codespell-ignore-words.txt"
+pre-commit install
+pre-commit autoupdate
+
+echo ""
+echo -e "${TERMINAL_COLOR_BLUE}FINISHED formatting setup: Now commit the formatting configuration and format all files using \`pre-commit run -a\` command.${TERMINAL_COLOR_NC}"

--- a/scripts/setup-repository-ci.bash
+++ b/scripts/setup-repository-ci.bash
@@ -200,11 +200,7 @@ read -p "${RAW_TERMINAL_COLOR_BROWN}Do you want to setup formatting using pre-co
 formatting=${formatting:="no"}
 
 if  [[ "$formatting" == "yes" ]]; then
-  cp -n ${PACKAGE_TEMPLATES}/.clang-format .
-  cp -n ${PACKAGE_TEMPLATES}/.pre-commit-config.yaml .
-  touch ".codespell-ignore-words.txt"
-  pre-commit install
-  pre-commit autoupdate
+  $RosTeamWS_FRAMEWORK_SCRIPTS_PATH/setup-formatting.bash
 fi
 
 echo ""

--- a/scripts/setup-repository.bash
+++ b/scripts/setup-repository.bash
@@ -91,10 +91,13 @@ case "$choice" in
   exit 0
 esac
 
-cp -n $PACKAGE_TEMPLATES/.clang-format .
-cp -n $PACKAGE_TEMPLATES/.pre-commit-config.yaml .
-pre-commit install
-pre-commit autoupdate
+# Setting up formatting
+read -p "${RAW_TERMINAL_COLOR_BROWN}Do you want to setup formatting using pre-commit?${RAW_TERMINAL_COLOR_NC} (yes/no) [no]: " formatting
+formatting=${formatting:="no"}
+
+if  [[ "$formatting" == "yes" ]]; then
+  $RosTeamWS_FRAMEWORK_SCRIPTS_PATH/setup-formatting.bash
+fi
 
 
 # This functionality is not provided in all framework versions


### PR DESCRIPTION
@SahWag can you test this changes. The best test is to do it in the wild. My proposal:

1. Setup formatting for all repositories that are stored in GitLab for the current project (use `setup-formatting` alias)
3. Commit the formatting setup and after that format the code as instructed at the end of the script and commit this separately.
4. Setup CI on the open-source repositories used in current project using `ṡetup-repository-ci` alias. This should also automatically setup the formatting.
5. After setting the first repository, compare the CI setup to ros2_control and report any differences. We probably have to update our templates.
6. Merge / push configuration and changes separately. Then you will also see if there are any changes on the CI setup needed.
7. Report any issues or needed changes.
8. Finally, document the functionality in this repository, if something is missing.