### PR TITLE
Ignore flake8 style rule E203

### DIFF
--- a/templates/package/.pre-commit-config.yaml
+++ b/templates/package/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
     rev: 6.0.0
     hooks:
     - id: flake8
-      args: ["--extend-ignore=E501"]
+      args: ["--extend-ignore=E501,E203"]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0


### PR DESCRIPTION
flake8 rule E203(https://www.flake8rules.com/rules/E203.html) conflict with code formatter black(https://github.com/psf/black), which are both included in the pre-commit config yaml. This causes some edge-cases with indexing in python where the pre-commit will never pass.

This merge request turns off rule E203, thus avoiding this conflict