### PR TITLE
updated dev guidelines to clarify fork requirement

### DIFF
--- a/docs/guidelines/development.rst
+++ b/docs/guidelines/development.rst
@@ -27,7 +27,7 @@ This section describes in short the process with valuable tips to make your and 
 
    .. note::
 
-      In *Stogl Robotics* we have the organization called `StoglRobotics-forks <https://github.com/StoglRobotics-forks>`_ where all forks of public repositories live and are accessible for writing by all team members.
+      In *Stogl Robotics* we have the organization called `StoglRobotics-forks <https://github.com/StoglRobotics-forks>`_ where all forks of 3\ :sup:`rd` party public repositories live and are accessible for writing by all team members.
       This simplifies collaboration inside the team - there is no need for individual access grants when using forks under your user.
       **Always** check if there is already a fork in *StoglRobotics-forks* organization and if not create it.
 


### PR DESCRIPTION
- Updated the docs/guidelines/development.rst file to specify that the StoglRobotics-forks organization contains only forks of 3rd party public repositories. 
- This change clarifies the nature of the repositories in the organization, ensuring that it's understood they are exclusively third-party forks and not original Stogl Robotics repositories. 
- Also, integrated RST syntax for typographically correct superscript in '3rd'.