### PR TITLE
remove ^| from .ros2_control.xacro template

### DIFF
--- a/templates/robot_description/robot_macro.ros2_control.xacro
+++ b/templates/robot_description/robot_macro.ros2_control.xacro
@@ -4,10 +4,10 @@
   <xacro:macro name="$ROBOT_NAME$_ros2_control" params="
                name
                prefix
-               use_mock_hardware:=^|false
-               mock_sensor_commands:=^|false
-               sim_gazebo_classic:=^|false
-               sim_gazebo:=^|false
+               use_mock_hardware:=false
+               mock_sensor_commands:=false
+               sim_gazebo_classic:=false
+               sim_gazebo:=false
                simulation_controllers"
                >
 


### PR DESCRIPTION
Remove the ^| from template. We don't want to take definitions from outer scope. It's better to make it explicit what is passed to the macro