### PR TITLE
Fix bringup template

### DIFF
--- a/templates/ros2_control/robot_controllers.yaml
+++ b/templates/ros2_control/robot_controllers.yaml
@@ -67,6 +67,11 @@ joint_trajectory_controller:                  # delete entry if controller is no
       - joint5
       - joint6
 
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      
     state_publish_rate: 50.0 # Defaults to 50
     action_monitor_rate: 20.0 # Defaults to 20
 

--- a/templates/ros2_control/robot_ros2_control.launch.py
+++ b/templates/ros2_control/robot_ros2_control.launch.py
@@ -87,7 +87,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "robot_controller",
-            default_value="forward_position_controller",
+            default_value="joint_trajectory_controller",
             choices=["forward_position_controller", "joint_trajectory_controller"],
             description="Robot controller to start.",
         )

--- a/templates/ros2_control/robot_ros2_control.launch.xml
+++ b/templates/ros2_control/robot_ros2_control.launch.xml
@@ -46,7 +46,7 @@ Authors: Riyan Jose, Manuel Muth, Dr. Denis
        default="forward_position_controller"
        description="Robot controller to start. Choices are: [forward_position_controller, joint_trajectory_controller]."/>
   <arg name="inactive_robot_controller"
-       default="forward_position_controller"
+       default="joint_trajectory_controller"
        description="Robot controller to start inactive. Choices are: [forward_position_controller, joint_trajectory_controller]."/>
 
   <let name="robot_description_content" value="$(command '$(find-exec xacro) $(find-pkg-share $(var description_package))/urdf/$(var description_file).urdf.xacro prefix:=$(var prefix) use_mock_hardware:=$(var use_mock_hardware) mock_sensor_commands:=$(var mock_sensor_commands)')"/>

--- a/templates/ros2_control/robot_ros2_control.launch.xml
+++ b/templates/ros2_control/robot_ros2_control.launch.xml
@@ -43,10 +43,10 @@ Authors: Riyan Jose, Manuel Muth, Dr. Denis
        default="false"
        description="Enable mock command interfaces for sensors used for simple simulations. Used only if 'use_mock_hardware' parameter is true."/>
   <arg name="robot_controller"
-       default="forward_position_controller"
+       default="joint_trajectory_controller"
        description="Robot controller to start. Choices are: [forward_position_controller, joint_trajectory_controller]."/>
   <arg name="inactive_robot_controller"
-       default="joint_trajectory_controller"
+       default="forward_position_controller"
        description="Robot controller to start inactive. Choices are: [forward_position_controller, joint_trajectory_controller]."/>
 
   <let name="robot_description_content" value="$(command '$(find-exec xacro) $(find-pkg-share $(var description_package))/urdf/$(var description_file).urdf.xacro prefix:=$(var prefix) use_mock_hardware:=$(var use_mock_hardware) mock_sensor_commands:=$(var mock_sensor_commands)')"/>


### PR DESCRIPTION
Found a small issue when generating bringup package:
- generated `launch.xml` file tries to load `forward_position_controller` as both active and inactive, causing crashes
- `JTC` needs a default `command` and `state_interfaces` to be set so that it can be configured, even when loading it as inactive