### PR TITLE
nala related correction

### DIFF
--- a/scripts/setup-ros-workspace.bash
+++ b/scripts/setup-ros-workspace.bash
@@ -376,16 +376,11 @@ create_workspace_docker () {
     let CUT_LINE=$TEST_LINE+0
     tail -n +$CUT_LINE $TMP_FILE >> $DOCKER_FILE
 
-    # Add repositories for Nala
-    mv $DOCKER_FILE "$TMP_FILE"
-    TEST_LINE=`awk '$1 == "#" && $2 == "install" && $3 == "nala" { print NR }' $TMP_FILE`  # get line before `# install nala and upgrade` dependency
-    let CUT_LINE=$TEST_LINE-0
-    head -$CUT_LINE $TMP_FILE > $DOCKER_FILE
 
     # Add last part
     let CUT_LINE=$TEST_LINE+2
     tail -n +$CUT_LINE $TMP_FILE >> $DOCKER_FILE
-
+    
     # Cleanup temp files
     rm $TMP_FILE
   fi

--- a/scripts/setup-ros-workspace.bash
+++ b/scripts/setup-ros-workspace.bash
@@ -380,7 +380,6 @@ create_workspace_docker () {
     # Add last part
     let CUT_LINE=$TEST_LINE+2
     tail -n +$CUT_LINE $TMP_FILE >> $DOCKER_FILE
-    
     # Cleanup temp files
     rm $TMP_FILE
   fi


### PR DESCRIPTION
These lines should also be removed as the comment "# install nala and upgrade" doesnt exist anymore TEST_LINE= will hold unexpected value and this was causing deletion of the first line in generated dockerfile at /.rtw_docker_defines/Dockerfile, and absence of the first line which is FROM nvidia/cuda:11.7.1-base-xxxx, was causing errors as below...
 
Dockerfile:9
--------------------
   7 |     
   8 |     # make bash default
   9 | >>> SHELL ["/bin/bash", "-c"]



