### PR TITLE
Add Flag to Disable Automatic Upgrades in Script

### DIFF
--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -122,6 +122,7 @@ class CreateVerbArgs:
     repos_no_skip_existing: bool = False
     disable_nvidia: bool = False
     docker: bool = False
+    disable_upgrade: bool = False
 
     @property
     def ws_name(self) -> str:
@@ -386,6 +387,14 @@ class CreateVerb(VerbExtension):
             default=False,
         )
         parser.add_argument(
+            "--disable-upgrade",
+            action="store_true",
+            help="Disable upgrade flag",
+            default=False,
+        )
+        
+        
+        parser.add_argument(
             "--ws-repos-file-name",
             type=str,
             help=(
@@ -601,7 +610,7 @@ class CreateVerb(VerbExtension):
         return textwrap.dedent(
             f"""
             FROM {create_args.base_image_name}
-            RUN apt-get update && apt-get upgrade -y
+            RUN apt-get update {"&& apt-get upgrade -y" if not create_args.disable_upgrade else ""}
             {apt_packages_cmd}
             {python_packages_cmd}
             {rtw_clone_cmd}

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -389,7 +389,7 @@ class CreateVerb(VerbExtension):
         parser.add_argument(
             "--disable-upgrade",
             action="store_true",
-            help="Disable upgrade flag",
+            help="Disable execution of 'apt-get upgrade' when creating workspace.",
             default=False,
         )
         parser.add_argument(

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -392,8 +392,6 @@ class CreateVerb(VerbExtension):
             help="Disable upgrade flag",
             default=False,
         )
-        
-        
         parser.add_argument(
             "--ws-repos-file-name",
             type=str,

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
@@ -89,12 +89,6 @@ class ImportVerb(VerbExtension):
             default=False,
         )
         parser.add_argument(
-            "--disable-upgrade",
-            action="store_true",
-            help="Disable upgrade flag",
-            default=False,
-        )
-        parser.add_argument(
             "--final-image-name",
             type=str,
             help=(

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
@@ -36,7 +36,6 @@ class ImportVerbArgs:
     standalone_docker_image: str
     docker: bool = True
     disable_nvidia: bool = False
-    disable_upgrade: bool = False
     standalone: bool = True
     final_image_name: str = ""
     container_name: str = ""

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
@@ -141,7 +141,6 @@ class ImportVerb(VerbExtension):
         import_args = ImportVerbArgs(**filtered_args)
         rocker_flags = generate_rocker_flags(
             disable_nvidia=import_args.disable_nvidia,
-            disable_upgrade=import_args.disable_upgrade,
             container_name=import_args.container_name,
             hostname=import_args.hostname,
             ssh_abs_path=import_args.ssh_abs_path,

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
@@ -36,6 +36,7 @@ class ImportVerbArgs:
     standalone_docker_image: str
     docker: bool = True
     disable_nvidia: bool = False
+    disable_upgrade: bool = False
     standalone: bool = True
     final_image_name: str = ""
     container_name: str = ""
@@ -89,6 +90,12 @@ class ImportVerb(VerbExtension):
             default=False,
         )
         parser.add_argument(
+            "--disable-upgrade",
+            action="store_true",
+            help="Disable upgrade flag",
+            default=False,
+        )
+        parser.add_argument(
             "--final-image-name",
             type=str,
             help=(
@@ -134,6 +141,7 @@ class ImportVerb(VerbExtension):
         import_args = ImportVerbArgs(**filtered_args)
         rocker_flags = generate_rocker_flags(
             disable_nvidia=import_args.disable_nvidia,
+            disable_upgrade=import_args.disable_upgrade,
             container_name=import_args.container_name,
             hostname=import_args.hostname,
             ssh_abs_path=import_args.ssh_abs_path,


### PR DESCRIPTION
This pull request introduces a new command-line flag `--disable-upgrade` to control the automatic upgrade process during the script execution.

This enhancement provides more control over the upgrade process, particularly useful in environments where upgrades need to be managed separately or manually.