### PR TITLE
Add hardware device permissions note to README template

### DIFF
--- a/templates/package/_append_to_README_ROS_Intro.md
+++ b/templates/package/_append_to_README_ROS_Intro.md
@@ -114,6 +114,15 @@ These instructions assume you are running Ubuntu 20.04:
    sudo apt install ros2-$ROS_DISTRO$-forward_command_controller ros2-$ROS_DISTRO$-joint_state_broadcaster ros2-$ROS_DISTRO$-joint_trajectory_controller ros2-$ROS_DISTRO$-xacro
    ```
 
+1. If you use real hardware, make sure your user has access to input devices and serial ports.
+   The `input` group allows access to devices such as joysticks and gamepads, and `dialout`
+   allows access to serial devices such as USB adapters and motor controllers:
+   ```
+   sudo usermod -aG input,dialout $(whoami)
+   ```
+
+   Log out and back in, or reboot, for the group changes to take effect.
+
 ### Configure and Build Workspace:
 To configure and build workspace execute following commands:
   ```


### PR DESCRIPTION
**Summary:**
Adds a brief note about input/dialout group access for real hardware, with the usermod command.

**Changes:**
Update templates/package/_append_to_README_ROS_Intro.md to mention input (joysticks/gamepads) and dialout (serial devices), with the usermod command.

**Testing:**
Not run (docs-only).