### PR TITLE
Mapping devices, adding groups, realtime options

### DIFF
--- a/docs/rtwcli/index.rst
+++ b/docs/rtwcli/index.rst
@@ -297,6 +297,7 @@ Hardware and device access
   the container is running. The option mounts ``/dev/input``, adds the required
   cgroup rules, and synchronizes the host ``input`` group into the container.
 
+
 Kernel scheduling and performance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -310,7 +311,10 @@ Kernel scheduling and performance
 
   .. note::
      Your host system must already be configured for real-time scheduling and
-     provide the ``realtime`` group. `See documentation on controls.ros.org <https://control.ros.org/rolling/doc/ros2_control/controller_manager/doc/userdoc.html#determinism>`_ for more info.
+     provide the ``realtime`` group.
+
+  For a complete step-by-step guide on setting up a PREEMPT_RT Debian system
+  and ROS workspace, see: `PREEMPT_RT PC setup <realtime_pc_setup.rst>`_
 
 Supplementary group permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/rtwcli/index.rst
+++ b/docs/rtwcli/index.rst
@@ -267,6 +267,41 @@ Docker build control
   Use this if you want to rebuild the image from scratch, for example after
   package repositories changed or when debugging dependency issues.
 
+APT package installation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+A predefined set of base packages (``BASE_APT_PACKAGES``) is always installed
+into the Docker image during the build. These include common tools such as
+``git``, ``vim``, ``tmux``, ``python3-colcon-common-extensions``, and others
+required for a functional ROS development environment.
+
+* ``--no-base-apt-packages``: Skip the installation of ``BASE_APT_PACKAGES``.
+
+  Use this for minimal images or when the base image already provides these
+  tools.
+
+  .. code-block:: bash
+
+     rtw workspace create \
+        --ws-folder my_minimal_ws \
+        --ros-distro jazzy \
+        --docker \
+        --no-base-apt-packages
+
+* ``--additional_apt_packages [PKG ...]``: Install extra apt packages on top of
+  ``BASE_APT_PACKAGES`` (or instead of them if ``--no-base-apt-packages`` is
+  set). These are installed in a separate ``RUN`` layer after the base packages.
+
+  Example:
+
+  .. code-block:: bash
+
+     rtw workspace create \
+        --ws-folder my_robot_ws \
+        --ros-distro jazzy \
+        --docker \
+        --additional_apt_packages ros-jazzy-rviz2 htop can-utils
+
 Hardware and device access
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/rtwcli/index.rst
+++ b/docs/rtwcli/index.rst
@@ -251,6 +251,105 @@ can access the internet through the proxy during the Docker image build process.
    company CA certificate using ``--proxy-ca-cert`` to avoid SSL verification
    errors during package installation.
 
+How to configure advanced Docker options
+""""""""""""""""""""""""""""""""""""""""
+.. _rtwcli-advanced-docker-usage:
+
+When creating Docker workspaces with ``rtw workspace create --docker``, you can
+use additional options to control the Docker build, pass hardware devices into
+the container, and synchronize host group permissions.
+
+Docker build control
+~~~~~~~~~~~~~~~~~~~~
+
+* ``--no-cache``: Build the Docker image without using the Docker build cache.
+
+  Use this if you want to rebuild the image from scratch, for example after
+  package repositories changed or when debugging dependency issues.
+
+Hardware and device access
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``--devices [DEV ...]``: Pass one or more device nodes from the host into the
+  container.
+
+  Example:
+
+  .. code-block:: bash
+
+     rtw workspace create \
+        --ws-folder my_robot_ws \
+        --ros-distro jazzy \
+        --docker \
+        --devices /dev/ttyUSB0 /dev/video0
+
+  This is useful for hardware such as serial adapters or cameras.
+
+  .. important::
+     Devices passed with ``--devices`` must be available before the container
+     starts. If such a device is unplugged and plugged in again, the container
+     will usually need to be restarted.
+
+* ``--enable-input``: Enable access to the Linux input subsystem for devices
+  such as joysticks, keyboards, and mice.
+
+  This is useful when input devices may be disconnected and reconnected while
+  the container is running. The option mounts ``/dev/input``, adds the required
+  cgroup rules, and synchronizes the host ``input`` group into the container.
+
+Kernel scheduling and performance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``--enable-realtime``: Enable real-time scheduling support inside the
+  container.
+
+  This is useful for workloads that require deterministic timing, such as
+  low-latency ROS 2 control loops. The option adjusts the required resource
+  limits, adds the ``SYS_NICE`` capability, and synchronizes the host
+  ``realtime`` group into the container.
+
+  .. note::
+     Your host system must already be configured for real-time scheduling and
+     provide the ``realtime`` group. `See documentation on controls.ros.org <https://control.ros.org/rolling/doc/ros2_control/controller_manager/doc/userdoc.html#determinism>`_ for more info.
+
+Supplementary group permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``--groups [GROUP ...]``: Synchronize supplementary groups from the host into
+  the container.
+
+  Example:
+
+  .. code-block:: bash
+
+     rtw workspace create \
+        --ws-folder my_robot_ws \
+        --ros-distro jazzy \
+        --docker \
+        --devices /dev/ttyUSB0 \
+        --groups dialout
+
+  This is useful when a device requires group-based access, for example when a
+  serial device is owned by the ``dialout`` group.
+
+  If a requested group does not exist on the host machine, the build will fail
+  instead of creating an invalid container configuration.
+
+* Combined example:
+
+  If you need a fresh build for a robot requiring a webcam, a dynamically pluggable Xbox controller, and a serial microcontroller:
+
+.. code-block:: bash
+
+   rtw workspace create \
+      --ws-folder my_robot_ws \
+      --ros-distro jazzy \
+      --docker \
+      --no-cache \
+      --devices /dev/video0 /dev/ttyACM0 \
+      --enable-input \
+      --groups video dialout
+
 
 How to install rocker fork with the new features
 """"""""""""""""""""""""""""""""""""""""""""""""""

--- a/docs/rtwcli/index.rst
+++ b/docs/rtwcli/index.rst
@@ -270,7 +270,7 @@ Docker build control
 Hardware and device access
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* ``--devices [DEV ...]``: Pass one or more device nodes from the host into the
+* ``--devices [DEV ...]``: Pass one or more device paths from the host into the
   container.
 
   Example:
@@ -315,6 +315,7 @@ Kernel scheduling and performance
 
   For a complete step-by-step guide on setting up a PREEMPT_RT Debian system
   and ROS workspace, see: `PREEMPT_RT PC setup <realtime_pc_setup.rst>`_
+
 
 Supplementary group permissions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/rtwcli/realtime_pc_setup.rst
+++ b/docs/rtwcli/realtime_pc_setup.rst
@@ -40,7 +40,7 @@ Initial System Setup
 .. code-block:: bash
 
    su -
-   usermod -a -G sudo core
+   usermod -a -G sudo <user_name>
    exit
 
 8. Re-login and verify sudo access.

--- a/docs/rtwcli/realtime_pc_setup.rst
+++ b/docs/rtwcli/realtime_pc_setup.rst
@@ -1,0 +1,164 @@
+Realtime PC Setup
+====================================
+
+This guide describes the recommended and simplest way to set up a
+real-time (PREEMPT_RT) PC and prepare it for ROS 2 development using RTW.
+
+We're using a pre-build binary on Linux Debian distribution and a docker container
+with Ubuntu 24.04 with real-time permissions.
+
+Operating System Installation
+-----------------------------
+
+1. Download the newest Debian stable version.
+
+   It is recommended to use the *complete installation image* from:
+   https://www.debian.org/CD/
+
+2. Create a bootable USB (e.g., using ``dd`` on Linux).
+
+3. Boot from the USB and select ``Graphical Installer``.
+
+4. Follow installation steps:
+
+   * Be aware Debian uses a separate ``root`` user. Don't get confused with two passwords. Debian has root user that doesn't have name, and you can access it with ``su -`` command.
+   * Install ``ssh`` during setup
+   * Choose your preferred window manager
+
+5. Configure networking:
+
+   * Main network according to your company requirements
+   * Set up a dedicated RT ethernet interface for your robot with a static IP.
+
+Initial System Setup
+-------------------
+
+6. Connect via SSH from engineering PC.
+
+7. Add your user to sudo:
+
+.. code-block:: bash
+
+   su -
+   usermod -a -G sudo core
+   exit
+
+8. Re-login and verify sudo access.
+
+9. Update system:
+
+.. code-block:: bash
+
+   sudo apt update
+
+PREEMPT_RT Kernel Installation
+------------------------------
+
+10. Check current kernel:
+
+.. code-block:: bash
+
+   uname -r
+
+11. Install matching RT kernel:
+
+Check the current kernel version with ``uname -r``, e.g., ``6.12.74+deb13+1-amd64``.
+Then, install the exact same version of kernel with ``PREEMPT_RT`` flag
+
+.. code-block:: bash
+
+   sudo apt install linux-image-<version>-rt-amd64
+
+12. Reboot:
+
+.. code-block:: bash
+
+   sudo reboot
+
+13. Verify RT kernel:
+
+.. code-block:: bash
+
+   uname -a
+
+   # should contain PREEMPT_RT
+
+Realtime Permissions Setup
+-------------------------
+
+14. Install Docker (APT method):
+
+   https://docs.docker.com/engine/install/debian/
+
+15. Configure ``realtime`` and ``docker`` groups and configure limits:
+
+.. code-block:: bash
+
+   sudo usermod -aG docker $USER
+   sudo addgroup realtime
+   sudo usermod -aG realtime $USER
+
+   sudo tee -a /etc/security/limits.conf <<EOF
+   @realtime soft rtprio 99
+   @realtime soft priority 99
+   @realtime soft memlock unlimited
+   @realtime hard rtprio 99
+   @realtime hard priority 99
+   @realtime hard memlock unlimited
+   EOF
+
+16. Logout/login and verify:
+
+You should see ``docker`` and ``realtime`` groups in the output.
+
+.. code-block:: bash
+
+   groups
+
+RTW and ROS Workspace Setup
+---------------------------
+
+17. Install RTW:
+
+   https://rtw.b-robotized.com/master/tutorials/setting_up_rtw.html
+
+18. Create RT-enabled workspace:
+
+.. code-block:: bash
+
+   rtw workspace create \
+      --ws-folder <my-ws-name> \
+      --ros-distro <my-distro> \
+      --docker \
+      --disable-nvidia \
+      --repos-containing-repository-url \
+         https://<repo-url>.git \
+      --repos-branch master \
+      --apt_packages <additional-pkg-1>  \
+                    <additional-pkg-2>... \
+      --enable-realtime
+
+19. Exit container and source workspace:
+
+Exiting the container saves the workspace configuration in RTW.
+
+.. code-block:: bash
+
+   rtw ws <my-ws-name>
+
+20. Enter container:
+
+.. code-block:: bash
+
+   rtw docker enter
+
+Verification and Testing
+-----------------------
+
+21. Verify RT kernel inside container:
+
+.. code-block:: bash
+
+   uname -a
+
+   # should contain PREEMPT_RT

--- a/docs/rtwcli/realtime_pc_setup.rst
+++ b/docs/rtwcli/realtime_pc_setup.rst
@@ -23,12 +23,15 @@ Operating System Installation
 
    * Be aware Debian uses a separate ``root`` user. Don't get confused with two passwords. Debian has root user that doesn't have name, and you can access it with ``su -`` command.
    * Install ``ssh`` during setup
-   * Choose your preferred window manager
+   * Choose your preferred window manager _(recommended is Plasma)_
 
 5. Configure networking:
 
    * Main network according to your company requirements
-   * Set up a dedicated RT ethernet interface for your robot with a static IP.
+
+6. Login to the PC after installation _(recommended to use **Plasma on X11**)_:
+
+   * Set up a networking - usually your company network and dedicated RT ethernet interface for your robot with a static IP.
 
 Initial System Setup
 ---------------------

--- a/docs/rtwcli/realtime_pc_setup.rst
+++ b/docs/rtwcli/realtime_pc_setup.rst
@@ -8,7 +8,7 @@ We're using a pre-build binary on Linux Debian distribution and a docker contain
 with Ubuntu 24.04 with real-time permissions.
 
 Operating System Installation
------------------------------
+------------------------------
 
 1. Download the newest Debian stable version.
 
@@ -31,7 +31,7 @@ Operating System Installation
    * Set up a dedicated RT ethernet interface for your robot with a static IP.
 
 Initial System Setup
--------------------
+---------------------
 
 6. Connect via SSH from engineering PC.
 
@@ -52,7 +52,7 @@ Initial System Setup
    sudo apt update
 
 PREEMPT_RT Kernel Installation
-------------------------------
+-------------------------------
 
 10. Check current kernel:
 
@@ -84,7 +84,7 @@ Then, install the exact same version of kernel with ``PREEMPT_RT`` flag
    # should contain PREEMPT_RT
 
 Realtime Permissions Setup
--------------------------
+---------------------------
 
 14. Install Docker (APT method):
 
@@ -116,7 +116,7 @@ You should see ``docker`` and ``realtime`` groups in the output.
    groups
 
 RTW and ROS Workspace Setup
----------------------------
+----------------------------
 
 17. Install RTW:
 
@@ -153,7 +153,7 @@ Exiting the container saves the workspace configuration in RTW.
    rtw docker enter
 
 Verification and Testing
------------------------
+-------------------------
 
 21. Verify RT kernel inside container:
 

--- a/rtwcli/README.md
+++ b/rtwcli/README.md
@@ -2,7 +2,7 @@
 
 `git clone https://github.com/b-robotized/ros_team_workspace.git`
 
-`cd ros_team_workspace/rtwcli/ && pip3 install -r requirements.txt`
+`cd ros_team_workspace/rtwcli/ && pip3 install --break-system-dependencies -r requirements.txt`
 
 `source ros_team_workspace/setup.bash`
 

--- a/rtwcli/requirements.txt
+++ b/rtwcli/requirements.txt
@@ -1,3 +1,4 @@
 -e ./rtwcli
 -e ./rtw_cmds
 -e ./rtw_rocker_extensions
+off-your-rocker

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -112,6 +112,7 @@ class CreateVerbArgs:
     container_name: str
     rtw_docker_repo_url: str
     rtw_docker_branch: str
+    no_cache: bool
     rtw_docker_clone_abs_path: str
     ssh_abs_path: str
     intermediate_dockerfile_name: str
@@ -434,6 +435,12 @@ class CreateVerb(VerbExtension):
                 f"default format is used: {DEFAULT_WS_REPOS_FILE_FORMAT}"
             ),
             default=None,
+        )
+        parser.add_argument(
+            "--no-cache",
+            action="store_true",
+            help="Do not use cache when building the docker image.",
+            default=False,
         )
         parser.add_argument(
             "--upstream-ws-repos-file-name",
@@ -794,6 +801,7 @@ RUN rm -rf /var/lib/apt/lists/*
             tag=create_args.final_image_name,
             dockerfile_path=docker_build_context,
             file=create_args.intermediate_dockerfile_abs_path,
+            no_cache=create_args.no_cache,
         ):
             # clean up certificate file from build context even on failure
             if cert_dest_path and os.path.exists(cert_dest_path):

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -15,6 +15,7 @@
 
 import argparse
 from dataclasses import dataclass, field, fields
+import grp
 import os
 import shutil
 import subprocess
@@ -135,6 +136,10 @@ class CreateVerbArgs:
     proxy_server: str = ""
     proxy_ca_cert: str = ""
     env_vars: dict = field(default_factory=dict)
+    devices: List[str] = field(default_factory=list)
+    use_groups: List[str] = field(default_factory=list)
+    enable_input: bool = False
+    enable_realtime: bool = False
 
     @property
     def ssh_abs_path_in_docker(self) -> str:
@@ -410,6 +415,29 @@ class CreateVerb(VerbExtension):
             default=False,
         )
         parser.add_argument(
+            "--enable-input",
+            action="store_true",
+            help="Enable dynamic hot-plugging for joysticks and input devices (binds whole /dev/input).",
+        )
+        parser.add_argument(
+            "--enable-realtime",
+            action="store_true",
+            help="Enable realtime kernel scheduling capabilities (rtprio, memlock, sys_nice).",
+        )
+        parser.add_argument(
+            "--devices",
+            nargs="*",
+            help="Statically mount specific devices (e.g., /dev/ttyUSB0). Must be plugged in at container startup.",
+            default=[],
+        )
+        parser.add_argument(
+            "--groups",
+            dest="use_groups",
+            nargs="*",
+            help="Additional host groups to pass to the container (e.g., input, realtime, dialout, video).",
+            default=[],
+        )
+        parser.add_argument(
             "--enable-ipc",
             action="store_true",
             help="Enable IPC for the docker workspace.",
@@ -635,6 +663,29 @@ class CreateVerb(VerbExtension):
         else:
             python_packages_cmd = "# no python packages to install"
 
+        # --- SYNC HOST GROUPS TO CONTAINER ---
+        groups_to_sync = create_args.use_groups.copy() if create_args.use_groups else []
+        if getattr(create_args, "enable_input", False):
+            groups_to_sync.append('input')
+        if getattr(create_args, "enable_realtime", False):
+            groups_to_sync.append('realtime')
+
+        group_sync_cmds = []
+        for group_name in set(groups_to_sync):
+            try:
+                gid = grp.getgrnam(group_name).gr_gid
+                # If the group exists, force its GID to match the host. If missing, create it.
+                cmd = (
+                    f"RUN if getent group {group_name} > /dev/null 2>&1; then "
+                    f"groupmod -g {gid} {group_name} || true; else "
+                    f"groupadd -g {gid} {group_name}; fi"
+                )
+                group_sync_cmds.append(cmd)
+            except KeyError:
+                raise RuntimeError(f"Requested group '{group_name}' does not exist on the host system.")
+                
+        group_sync_cmd_str = "\n".join(group_sync_cmds)
+
         rtw_clone_cmd = " ".join(
             [
                 "RUN",
@@ -761,6 +812,7 @@ FROM {create_args.base_image_name}
 {update_key_cmds}
 RUN apt-get update {"&& apt-get upgrade -y" if not create_args.docker_disable_upgrade else ""}
 {apt_packages_cmd}
+{group_sync_cmd_str}
 {pip_config_cmd}
 {git_config_cmd}
 {python_packages_cmd}
@@ -1285,6 +1337,10 @@ RUN rm -rf /var/lib/apt/lists/*
                 ws_volumes=rocker_ws_volumes,
                 user_override_name=create_args.user_override_name,
                 env_file=create_args.env_file,
+                devices=create_args.devices,
+                use_groups=create_args.use_groups,
+                enable_input=create_args.enable_input,
+                enable_realtime=create_args.enable_realtime,
             )
 
             if not execute_rocker_cmd(rocker_flags, create_args.rocker_base_image_name):

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -1096,7 +1096,9 @@ RUN rm -rf /var/lib/apt/lists/*
 
         logger.info(f"Committing container '{intermediate_container.id}'")
         try:
-            intermediate_container.commit(create_args.final_image_name)
+            docker_client_commit = docker.from_env(timeout=600)
+            container_to_commit = docker_client_commit.containers.get(intermediate_container.id)
+            container_to_commit.commit(repository=create_args.final_image_name)
         except docker.errors.APIError as e:  # type: ignore
             docker_stop(intermediate_container.id)
             raise RuntimeError(f"Failed to commit container '{intermediate_container.id}': {e}")

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass, field, fields
 import grp
 import os
 import shutil
-import subprocess
 import textwrap
 from typing import Any, List
 
@@ -666,9 +665,9 @@ class CreateVerb(VerbExtension):
         # --- SYNC HOST GROUPS TO CONTAINER ---
         groups_to_sync = create_args.use_groups.copy() if create_args.use_groups else []
         if getattr(create_args, "enable_input", False):
-            groups_to_sync.append('input')
+            groups_to_sync.append("input")
         if getattr(create_args, "enable_realtime", False):
-            groups_to_sync.append('realtime')
+            groups_to_sync.append("realtime")
 
         group_sync_cmds = []
         for group_name in set(groups_to_sync):
@@ -682,8 +681,10 @@ class CreateVerb(VerbExtension):
                 )
                 group_sync_cmds.append(cmd)
             except KeyError:
-                raise RuntimeError(f"Requested group '{group_name}' does not exist on the host system.")
-                
+                raise RuntimeError(
+                    f"Requested group '{group_name}' does not exist on the host system."
+                )
+
         group_sync_cmd_str = "\n".join(group_sync_cmds)
 
         rtw_clone_cmd = " ".join(
@@ -1137,7 +1138,7 @@ RUN rm -rf /var/lib/apt/lists/*
             if create_args.docker:
                 import docker
 
-                client = docker.from_env(timeout=12000) # 20 min timeout on response timeout
+                client = docker.from_env(timeout=12000)  # 20 min timeout on response timeout
                 uid = os.getuid()
                 gid = os.getgid()
 

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -1097,7 +1097,7 @@ RUN rm -rf /var/lib/apt/lists/*
 
         logger.info(f"Committing container '{intermediate_container.id}'")
         try:
-            docker_client_commit = docker.from_env(timeout=600)
+            docker_client_commit = docker.from_env(timeout=12000)  # 20 min timeout on response timeout
             container_to_commit = docker_client_commit.containers.get(intermediate_container.id)
             container_to_commit.commit(repository=create_args.final_image_name)
         except docker.errors.APIError as e:  # type: ignore

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -73,7 +73,7 @@ DEFAULT_RTW_DOCKER_PATH = os.path.expanduser("~/ros_team_workspace")
 DEFAULT_UPSTREAM_WS_NAME_FORMAT = "{workspace_name}_upstream"
 DEFAULT_WS_REPOS_FILE_FORMAT = "{repo_name}.{ros_distro}.repos"
 DEFAULT_UPSTREAM_WS_REPOS_FILE_FORMAT = "{repo_name}.{ros_distro}.upstream.repos"
-DEFAULT_APT_PACKAGES = [
+BASE_APT_PACKAGES = [
     "bash-completion",
     "git",
     "git-lfs",
@@ -121,7 +121,8 @@ class CreateVerbArgs:
     user_override_name: str
     has_upstream_ws: bool = False
     ignore_ws_cmd_error: bool = False
-    apt_packages: List[str] = field(default_factory=list)
+    additional_apt_packages: List[str] = field(default_factory=list)
+    no_base_apt_packages: bool = False
     python_packages: List[str] = field(default_factory=list)
     standalone: bool = False
     repos_no_skip_existing: bool = False
@@ -539,10 +540,23 @@ class CreateVerb(VerbExtension):
             default=DEFAULT_RTW_DOCKER_PATH,
         )
         parser.add_argument(
-            "--apt_packages",
+            "--additional_apt_packages",
             nargs="*",
-            help="Additional apt packages to install.",
-            default=DEFAULT_APT_PACKAGES,
+            help=(
+                "Additional apt packages to install on top of BASE_APT_PACKAGES. "
+                "These are installed in a separate RUN layer after the base packages."
+            ),
+            default=[],
+        )
+        parser.add_argument(
+            "--no-base-apt-packages",
+            action="store_true",
+            help=(
+                "Skip installation of BASE_APT_PACKAGES. "
+                "Use this for minimal images or when the base image already provides these tools. "
+                f"BASE_APT_PACKAGES: {BASE_APT_PACKAGES}"
+            ),
+            default=False,
         )
         parser.add_argument(
             "--python_packages",
@@ -626,12 +640,13 @@ class CreateVerb(VerbExtension):
         )
 
     def generate_intermediate_dockerfile_content(self, create_args: CreateVerbArgs) -> str:
-        if create_args.apt_packages:
-            apt_packages_cmd = " ".join(
-                ["RUN", "apt-get", "install", "-y"] + create_args.apt_packages
+        apt_packages_cmd = "# no apt packages to install"
+        if not create_args.no_base_apt_packages:
+            apt_packages_cmd = " ".join(["RUN", "apt-get", "install", "-y"] + BASE_APT_PACKAGES)
+        if create_args.additional_apt_packages:
+            apt_packages_cmd += "\n" + " ".join(
+                ["RUN", "apt-get", "install", "-y"] + create_args.additional_apt_packages
             )
-        else:
-            apt_packages_cmd = "# no apt packages to install"
 
         if create_args.python_packages:
             # hack to install system-wide python packages
@@ -1097,7 +1112,9 @@ RUN rm -rf /var/lib/apt/lists/*
 
         logger.info(f"Committing container '{intermediate_container.id}'")
         try:
-            docker_client_commit = docker.from_env(timeout=12000)  # 20 min timeout on response timeout
+            docker_client_commit = docker.from_env(
+                timeout=12000
+            )  # 20 min timeout on response timeout
             container_to_commit = docker_client_commit.containers.get(intermediate_container.id)
             container_to_commit.commit(repository=create_args.final_image_name)
         except docker.errors.APIError as e:  # type: ignore

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -855,7 +855,6 @@ RUN rm -rf /var/lib/apt/lists/*
             rosdep_cmds = [["sudo", "apt-get", "update"], ["rosdep", "update"]]
         else:
             rosdep_cmds = []
-        os_codename = subprocess.check_output(["lsb_release", "-c", "-s"], text=True).strip()
         rosdep_install_cmd_base = [
             "rosdep",
             "install",
@@ -863,7 +862,6 @@ RUN rm -rf /var/lib/apt/lists/*
             "-r",
             "-y",
             f"--rosdistro={create_args.ros_distro}",
-            f"--os=ubuntu:{os_codename}",
             "--from-paths",
         ]
         if has_upstream_ws_packages:
@@ -1077,7 +1075,7 @@ RUN rm -rf /var/lib/apt/lists/*
             if create_args.docker:
                 import docker
 
-                client = docker.from_env()
+                client = docker.from_env(timeout=12000) # 20 min timeout on response timeout
                 uid = os.getuid()
                 gid = os.getgid()
 

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/import_verb.py
@@ -148,6 +148,7 @@ class ImportVerb(VerbExtension):
             ssh_abs_path_in_docker=import_args.ssh_abs_path_in_docker,
             final_image_name=import_args.final_image_name,
             user_override_name=import_args.user_override_name,
+            devices=import_args.devices,
         )
 
         if not execute_rocker_cmd(rocker_flags, import_args.standalone_docker_image):
@@ -168,6 +169,7 @@ class ImportVerb(VerbExtension):
             docker_tag=import_args.final_image_name,
             docker_container_name=import_args.container_name,
             standalone=import_args.standalone,
+            docker_devices=import_args.devices or [],
         )
         if not update_workspaces_config(WORKSPACES_PATH, local_main_ws):
             raise RuntimeError("Failed to update workspaces config with main workspace.")

--- a/rtwcli/rtwcli/rtwcli/constants.py
+++ b/rtwcli/rtwcli/rtwcli/constants.py
@@ -61,6 +61,8 @@ ROS_TEAM_WS_ENV_VARIABLES = [
 
 DISPLAY_MANAGER_WAYLAND = "wayland"
 
+OS_ID_DEBIAN = "debian"
+
 RICH_TREE_LABEL_COLOR = "[bold green]"
 RICH_TREE_GUIDE_STYLE = "bold"
 RICH_TREE_FST_LVL_COLOR = "[bold blue]"

--- a/rtwcli/rtwcli/rtwcli/docker_utils.py
+++ b/rtwcli/rtwcli/rtwcli/docker_utils.py
@@ -38,13 +38,13 @@ def docker_build(
     dockerfile_path: str,
     file: Union[str, None] = None,
     pull: bool = True,
-    no_cache: bool = True,
+    no_cache: bool = False,
 ) -> bool:
     """Build a docker image with the given tag from the given dockerfile path."""
     docker_build_command = ["docker", "build", "-t", tag]
+    docker_build_command.append("--progress=plain")
     if no_cache:
         docker_build_command.append("--no-cache")
-        docker_build_command.append("--progress=plain")
     if pull:
         docker_build_command.append("--pull")
     if file:

--- a/rtwcli/rtwcli/rtwcli/rocker_utils.py
+++ b/rtwcli/rtwcli/rtwcli/rocker_utils.py
@@ -35,7 +35,7 @@ def generate_rocker_flags(
     devices: Union[List[str], None] = None,
     enable_input: bool = False,
     enable_realtime: bool = False,
-    use_groups: Union[List[str], None] = None
+    use_groups: Union[List[str], None] = None,
 ) -> List[str]:
     # rocker flags have order, see rocker --help
     rocker_flags = ["--nocache", "--nocleanup", "--git"]
@@ -95,12 +95,10 @@ def generate_rocker_flags(
     # --- INPUT HARDWARE BINDINGS ---
     # off-your-rocker rocker extension, to add docker run args rocker does not support out of the box.
     oyr_run_args = []
-    
+
     if enable_input:
-        groups_to_add.append('input')
-        rocker_flags.extend([
-            "--volume", "/dev/input:/dev/input"
-        ])
+        groups_to_add.append("input")
+        rocker_flags.extend(["--volume", "/dev/input:/dev/input"])
         # In Linux hardware management, devices are categorized by a "Major" number.
         # The Major number 13 is permanently assigned by the Linux kernel to the entire Input Subsystem.
         # This 13 is a static kernel constant.
@@ -109,12 +107,16 @@ def generate_rocker_flags(
         oyr_run_args.append("--device-cgroup-rule='c 13:* rmw'")
 
     if enable_realtime:
-        groups_to_add.append('realtime')
-        rocker_flags.extend([
-            "--ulimit", "rtprio=99",
-            "--ulimit", "memlock=-1",
-        ])
-        oyr_run_args.append("--cap-add=sys_nice")    
+        groups_to_add.append("realtime")
+        rocker_flags.extend(
+            [
+                "--ulimit",
+                "rtprio=99",
+                "--ulimit",
+                "memlock=-1",
+            ]
+        )
+        oyr_run_args.append("--cap-add=sys_nice")
 
     # Resolve and add GIDs for all requested groups
     for group_name in set(groups_to_add):
@@ -124,7 +126,9 @@ def generate_rocker_flags(
             logger.info(f"SUCCESS: Added '{group_name}' group (GID: {gid}) to rocker flags.")
         except KeyError:
             # Abort if the user requested a group they don't actually have on the host system
-            raise RuntimeError(f"Requested group '{group_name}' does not exist on the host system. Please create it or remove the flag.")
+            raise RuntimeError(
+                f"Requested group '{group_name}' does not exist on the host system. Please create it or remove the flag."
+            )
 
     if oyr_run_args:
         raw_docker_args = " ".join(oyr_run_args)

--- a/rtwcli/rtwcli/rtwcli/rocker_utils.py
+++ b/rtwcli/rtwcli/rtwcli/rocker_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import grp
 from typing import List, Union
 
 from rtwcli import logger
@@ -31,6 +32,10 @@ def generate_rocker_flags(
     ws_volumes: Union[List[str], None] = None,
     user_override_name: Union[str, None] = None,
     env_file: Union[str, None] = None,
+    devices: Union[List[str], None] = None,
+    enable_input: bool = False,
+    enable_realtime: bool = False,
+    use_groups: Union[List[str], None] = None
 ) -> List[str]:
     # rocker flags have order, see rocker --help
     rocker_flags = ["--nocache", "--nocleanup", "--git"]
@@ -78,6 +83,53 @@ def generate_rocker_flags(
     rocker_flags.append("--rtw-tmpfs")
     rocker_flags.append("--rtw-update")
     rocker_flags.append("--x11")
+
+    # --- DEVICE MOUNTS ---
+    if devices:
+        for device in devices:
+            rocker_flags.extend(["--device", device])
+
+    # --- GROUPS ---
+    groups_to_add = use_groups.copy() if use_groups else []
+
+    # --- INPUT HARDWARE BINDINGS ---
+    # off-your-rocker rocker extension, to add docker run args rocker does not support out of the box.
+    oyr_run_args = []
+    
+    if enable_input:
+        groups_to_add.append('input')
+        rocker_flags.extend([
+            "--volume", "/dev/input:/dev/input"
+        ])
+        # In Linux hardware management, devices are categorized by a "Major" number.
+        # The Major number 13 is permanently assigned by the Linux kernel to the entire Input Subsystem.
+        # This 13 is a static kernel constant.
+        # We use it to grant the container access to all joysticks, mice, and keyboards at once.
+        # read this: https://docs.docker.com/reference/cli/docker/container/run/#device-cgroup-rule
+        oyr_run_args.append("--device-cgroup-rule='c 13:* rmw'")
+
+    if enable_realtime:
+        groups_to_add.append('realtime')
+        rocker_flags.extend([
+            "--ulimit", "rtprio=99",
+            "--ulimit", "memlock=-1",
+        ])
+        oyr_run_args.append("--cap-add=sys_nice")    
+
+    # Resolve and add GIDs for all requested groups
+    for group_name in set(groups_to_add):
+        try:
+            gid = grp.getgrnam(group_name).gr_gid
+            rocker_flags.extend(["--group-add", str(gid)])
+            logger.info(f"SUCCESS: Added '{group_name}' group (GID: {gid}) to rocker flags.")
+        except KeyError:
+            # Abort if the user requested a group they don't actually have on the host system
+            raise RuntimeError(f"Requested group '{group_name}' does not exist on the host system. Please create it or remove the flag.")
+
+    if oyr_run_args:
+        raw_docker_args = " ".join(oyr_run_args)
+        rocker_flags.extend(["--oyr-run-arg", raw_docker_args])
+
     rocker_flags.extend(["--mode", "interactive"])
     rocker_flags.extend(["--image-name", f"{final_image_name}"])
 

--- a/rtwcli/rtwcli/rtwcli/rocker_utils.py
+++ b/rtwcli/rtwcli/rtwcli/rocker_utils.py
@@ -17,8 +17,8 @@ import grp
 from typing import List, Union
 
 from rtwcli import logger
-from rtwcli.constants import DISPLAY_MANAGER_WAYLAND
-from rtwcli.utils import get_display_manager, run_command
+from rtwcli.constants import DISPLAY_MANAGER_WAYLAND, OS_ID_DEBIAN
+from rtwcli.utils import get_display_manager, get_os_id, run_command
 
 
 def generate_rocker_flags(
@@ -41,6 +41,10 @@ def generate_rocker_flags(
     rocker_flags = ["--nocache", "--nocleanup", "--git"]
 
     rocker_flags.extend(["-e", "QT_QPA_PLATFORM=xcb"])
+    if get_os_id() == OS_ID_DEBIAN:
+        rocker_flags.extend(["-e", "QT_X11_NO_MITSHM=1"])
+        rocker_flags.extend(["-e", "LIBGL_ALWAYS_SOFTWARE=1"])
+        rocker_flags.extend(["--device", "/dev/dri"])
     if not disable_nvidia:
         rocker_flags.extend(["-e", "__GLX_VENDOR_LIBRARY_NAME=nvidia"])
         rocker_flags.extend(["-e", "__NV_PRIME_RENDER_OFFLOAD=1"])

--- a/rtwcli/rtwcli/rtwcli/utils.py
+++ b/rtwcli/rtwcli/rtwcli/utils.py
@@ -174,6 +174,18 @@ def replace_user_name_in_path(
     return path.replace(f"/home/{current_user}", f"/home/{new_user}")
 
 
+def get_os_id() -> str:
+    """Read the OS ID from /etc/os-release (e.g. 'ubuntu', 'debian')."""
+    try:
+        with open("/etc/os-release") as f:
+            for line in f:
+                if line.startswith("ID="):
+                    return line.strip().split("=", 1)[1].strip('"').lower()
+    except OSError:
+        pass
+    return ""
+
+
 def get_display_manager() -> str:
     # Command to get the display manager type
     cmd = "loginctl show-session $(awk '/tty/ {print $1}' <(loginctl)) -p Type | awk -F= '{print $2}'"

--- a/rtwcli/rtwcli/rtwcli/workspace_utils.py
+++ b/rtwcli/rtwcli/rtwcli/workspace_utils.py
@@ -45,6 +45,7 @@ class Workspace:
     base_ws: Optional[str] = None
     standalone: bool = False
     env_vars: Dict[str, str] = dataclasses.field(default_factory=dict)
+    docker_devices: List[str] = dataclasses.field(default_factory=list)
 
     def __post_init__(self):
         if self.ws_folder == "":


### PR DESCRIPTION
Replaces https://github.com/b-robotized/ros_team_workspace/pull/306 and https://github.com/b-robotized/ros_team_workspace/pull/305.

* add static devices like dev/tty/USB0
* bind whole /dev/input/* + add user to `input` group with the same GID as host
* set realtime options for container and user to `realtime` group with the same GID as host
* enable adding the user in contianer to arbitrary named groups with same GID as host, like `dialout`
* docs, adjust arguments