### PR TITLE
Add ros2_kill command

### DIFF
--- a/scripts/_Team_Defines.bash
+++ b/scripts/_Team_Defines.bash
@@ -90,6 +90,10 @@ alias setup-rt-kernel="$RosTeamWS_FRAMEWORK_SCRIPTS_PATH"/setup-rt-kernel.bash
 # Setup RMW
 alias rtw-zenoh-router="$RosTeamWS_FRAMEWORK_SCRIPTS_PATH"/environment/rtw-zenoh-router.bash
 
+# Kill all running ROS 2 nodes
+alias ros2_kill="$RosTeamWS_FRAMEWORK_SCRIPTS_PATH"/environment/ros2_kill.bash
+alias ros2kill="$RosTeamWS_FRAMEWORK_SCRIPTS_PATH"/environment/ros2_kill.bash
+
 # VCS Aliases and helpers
 function rtw-ws-import () {
   # TODO: if not argument use WS default path for this after #169 is merged

--- a/scripts/_Team_Defines.bash
+++ b/scripts/_Team_Defines.bash
@@ -92,7 +92,6 @@ alias rtw-zenoh-router="$RosTeamWS_FRAMEWORK_SCRIPTS_PATH"/environment/rtw-zenoh
 
 # Kill all running ROS 2 nodes
 alias ros2_kill="$RosTeamWS_FRAMEWORK_SCRIPTS_PATH"/environment/ros2_kill.bash
-alias ros2kill="$RosTeamWS_FRAMEWORK_SCRIPTS_PATH"/environment/ros2_kill.bash
 
 # VCS Aliases and helpers
 function rtw-ws-import () {

--- a/scripts/environment/ros2_kill.bash
+++ b/scripts/environment/ros2_kill.bash
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2021-2026, b»robotized group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lists currently running ROS 2 nodes and kills their processes.
+
+echo "🔍 Listing ROS 2 nodes..."
+nodes=$(ros2 node list)
+
+if [ -z "$nodes" ]; then
+  echo "✅ No ROS 2 nodes are currently running."
+  exit 0
+fi
+
+echo "🧠 Resolving PIDs of ROS 2 nodes..."
+for node in $nodes; do
+  echo "➡ Node: $node"
+  pids=$(ps -eo pid,cmd | grep "$node" | grep -v grep | awk '{print $1}')
+  if [ -z "$pids" ]; then
+    echo "  ⚠ No PID found for $node"
+  else
+    for pid in $pids; do
+      echo "  ❌ Killing PID $pid"
+      kill -9 $pid
+    done
+  fi
+done
+
+echo "✅ Done."


### PR DESCRIPTION
## Summary
- Adds `scripts/environment/ros2_kill.bash`, a helper that lists running ROS 2 nodes via `ros2 node list` and `kill -9`s their resolved PIDs.
- Exposes the script as `ros2_kill` alias in `scripts/_Team_Defines.bash`, so any user who sources `setup.bash` gets the command on their PATH, no extra setup required.

## Motivation
Killing stuck ROS 2 nodes during development (e.g. after a controller crash or when a launch file leaves orphans behind) is a frequent chore. Giving rtw users a single command keeps the workflow consistent across the team instead of everyone copy-pasting their own `pkill` one-liner.

## Test plan
- [ ] `source setup.bash` in a fresh shell and confirm `type ros2_kill` resolve to `scripts/environment/ros2_kill.bash`.
- [ ] Run `ros2_kill` with **no** ROS 2 nodes running → prints `✅ No ROS 2 nodes are currently running.` and exits 0.
- [ ] Start a demo node (`ros2 run demo_nodes_cpp talker &`), run `ros2_kill`, confirm the talker process is gone (`pgrep -f talker` returns nothing) and `ros2 node list` is empty afterwards.
- [ ] `scripts/environment/ros2_kill.bash` is executable (`ls -l` shows `+x`).

Note: For stubborn nodes, you may need to run the command a couple times till it says `✅ No ROS 2 nodes are currently running.`

## Files changed
- `scripts/environment/ros2_kill.bash` (new)
- `scripts/_Team_Defines.bash` (alias line added under the RMW block)
