### PR TITLE
Added parameters to manage control overruns in launch templates

### DIFF
--- a/templates/ros2_control/bringup_control.launch.xml
+++ b/templates/ros2_control/bringup_control.launch.xml
@@ -73,14 +73,8 @@ Authors: Riyan Jose, Manuel Muth, Dr. Denis
 
   <!-- Doesn't work until fix releass, open from March 2026 -->
   <!-- <node pkg="controller_manager" exec="ros2_control_node" name="$(var controller_manager_name)" output="both"> -->
-  <node pkg="controller_manager" exec="ros2_control_node" output="both">
-    <param name="update_rate" value="100"/>
-    <param name="overruns.manage" value="$(var overrun_flags)"/>
-    <param name="overruns.print_warnings" value="$(var overrun_flags)"/>
-  </node>
-
- <!-- Suppress overrun warnings only when mock_hardware is true -->
   <group if="$(var use_mock)">
+     <!-- Suppress overrun warnings only when mock_hardware is true -->
      <node pkg="controller_manager" exec="ros2_control_node" output="both">
           <param name="update_rate" value="100"/>
           <param name="overruns.manage" value="false"/>

--- a/templates/ros2_control/bringup_control.launch.xml
+++ b/templates/ros2_control/bringup_control.launch.xml
@@ -71,23 +71,17 @@ Authors: Riyan Jose, Manuel Muth, Dr. Denis
     <arg name="robot_ip" value="$(var robot_ip)"/>
   </include>
 
+  <!-- Overruns disabled in mock mode, enabled for real hardware -->
+  <let name="overrun_enabled" value="false" if="$(var use_mock)"/>
+  <let name="overrun_enabled" value="true" unless="$(var use_mock)"/>
+
   <!-- Doesn't work until fix releass, open from March 2026 -->
   <!-- <node pkg="controller_manager" exec="ros2_control_node" name="$(var controller_manager_name)" output="both"> -->
-  <group if="$(var use_mock)">
-     <!-- Suppress overrun warnings only when mock_hardware is true -->
-     <node pkg="controller_manager" exec="ros2_control_node" output="both">
-          <param name="update_rate" value="100"/>
-          <param name="overruns.manage" value="false"/>
-          <param name="overruns.print_warnings" value="false"/>
-     </node>
-  </group>
-
-  <!-- Normal config for real hardware -->
-  <group unless="$(var use_mock)">
-     <node pkg="controller_manager" exec="ros2_control_node" output="both">
-          <param name="update_rate" value="100"/>
-     </node>
-  </group>
+  <node pkg="controller_manager" exec="ros2_control_node" output="both">
+       <param name="update_rate" value="100"/>
+       <param name="overruns.manage" value="$(var overrun_enabled)"/>
+       <param name="overruns.print_warnings" value="$(var overrun_enabled)"/>
+  </node>
 
   <let name="controllers_file_path" value="$(find-pkg-share $(var configuration_package))/config/$(var controllers_file)"/>
 

--- a/templates/ros2_control/bringup_control.launch.xml
+++ b/templates/ros2_control/bringup_control.launch.xml
@@ -40,6 +40,9 @@ Authors: Riyan Jose, Manuel Muth, Dr. Denis
   <arg name="use_mock"
        default="true"
        description="Start robot with mock hardware mirroring command to its states."/>
+  <arg name="overrun_flags"
+       default="true"
+       description="Set to true to manage controller overruns and print warnings. Set to false to disable overrun handling (useful for mock systems)."/>
   <arg name="start_rviz"
        default="true"
        description="Launch RViz visualization?"/>
@@ -75,6 +78,8 @@ Authors: Riyan Jose, Manuel Muth, Dr. Denis
   <!-- <node pkg="controller_manager" exec="ros2_control_node" name="$(var controller_manager_name)" output="both"> -->
   <node pkg="controller_manager" exec="ros2_control_node" output="both">
     <param name="update_rate" value="100"/>
+    <param name="overruns.manage" value="$(var overrun_flags)"/>
+    <param name="overruns.print_warnings" value="$(var overrun_flags)"/>
   </node>
 
   <let name="controllers_file_path" value="$(find-pkg-share $(var configuration_package))/config/$(var controllers_file)"/>

--- a/templates/ros2_control/bringup_control.launch.xml
+++ b/templates/ros2_control/bringup_control.launch.xml
@@ -40,9 +40,6 @@ Authors: Riyan Jose, Manuel Muth, Dr. Denis
   <arg name="use_mock"
        default="true"
        description="Start robot with mock hardware mirroring command to its states."/>
-  <arg name="overrun_flags"
-       default="true"
-       description="Set to true to manage controller overruns and print warnings. Set to false to disable overrun handling (useful for mock systems)."/>
   <arg name="start_rviz"
        default="true"
        description="Launch RViz visualization?"/>
@@ -81,6 +78,22 @@ Authors: Riyan Jose, Manuel Muth, Dr. Denis
     <param name="overruns.manage" value="$(var overrun_flags)"/>
     <param name="overruns.print_warnings" value="$(var overrun_flags)"/>
   </node>
+
+ <!-- Suppress overrun warnings only when mock_hardware is true -->
+  <group if="$(var use_mock)">
+     <node pkg="controller_manager" exec="ros2_control_node" output="both">
+          <param name="update_rate" value="100"/>
+          <param name="overruns.manage" value="false"/>
+          <param name="overruns.print_warnings" value="false"/>
+     </node>
+  </group>
+
+  <!-- Normal config for real hardware -->
+  <group unless="$(var use_mock)">
+     <node pkg="controller_manager" exec="ros2_control_node" output="both">
+          <param name="update_rate" value="100"/>
+     </node>
+  </group>
 
   <let name="controllers_file_path" value="$(find-pkg-share $(var configuration_package))/config/$(var controllers_file)"/>
 

--- a/templates/ros2_control/robot_ros2_control.launch.py
+++ b/templates/ros2_control/robot_ros2_control.launch.py
@@ -21,7 +21,13 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler, TimerAction
 from launch.event_handlers import OnProcessExit, OnProcessStart
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution, PythonExpression
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+    PythonExpression,
+)
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -151,8 +157,12 @@ def generate_launch_description():
             robot_description,
             robot_controllers,
             {
-                "overruns.manage": PythonExpression(["False if '", use_mock, "' in ('true', 'True', 'TRUE', '1') else True"]),
-                "overruns.print_warnings": PythonExpression(["False if '", use_mock, "' in ('true', 'True', 'TRUE', '1') else True"]),
+                "overruns.manage": PythonExpression(
+                    ["False if '", use_mock, "' in ('true', 'True', 'TRUE', '1') else True"]
+                ),
+                "overruns.print_warnings": PythonExpression(
+                    ["False if '", use_mock, "' in ('true', 'True', 'TRUE', '1') else True"]
+                ),
             },
         ],
     )

--- a/templates/ros2_control/robot_ros2_control.launch.py
+++ b/templates/ros2_control/robot_ros2_control.launch.py
@@ -20,9 +20,8 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler, TimerAction
-from launch.conditions import IfCondition, UnlessCondition
 from launch.event_handlers import OnProcessExit, OnProcessStart
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution, PythonExpression
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -144,28 +143,20 @@ def generate_launch_description():
         [FindPackageShare(description_package), "rviz", "$ROBOT_NAME$.rviz"]
     )
 
-    control_node_mock = Node(
+    control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
         output="both",
         parameters=[
             robot_description,
             robot_controllers,
-            {"overruns.manage": False, "overruns.print_warnings": False},
+            {
+                "overruns.manage": PythonExpression(["False if '", use_mock, "' in ('true', 'True', 'TRUE', '1') else True"]),
+                "overruns.print_warnings": PythonExpression(["False if '", use_mock, "' in ('true', 'True', 'TRUE', '1') else True"]),
+            },
         ],
-        condition=IfCondition(use_mock),
     )
-    control_node_real = Node(
-        package="controller_manager",
-        executable="ros2_control_node",
-        output="both",
-        parameters=[
-            robot_description,
-            robot_controllers,
-            {"overruns.manage": True, "overruns.print_warnings": True},
-        ],
-        condition=UnlessCondition(use_mock),
-    )
+
     robot_state_pub_node = Node(
         package="robot_state_publisher",
         executable="robot_state_publisher",
@@ -209,20 +200,9 @@ def generate_launch_description():
         ]
 
     # Delay loading and activation of `joint_state_broadcaster` after start of ros2_control_node
-    delay_joint_state_broadcaster_spawner_after_ros2_control_node_mock = RegisterEventHandler(
+    delay_joint_state_broadcaster_spawner_after_ros2_control_node = RegisterEventHandler(
         event_handler=OnProcessStart(
-            target_action=control_node_mock,
-            on_start=[
-                TimerAction(
-                    period=3.0,
-                    actions=[joint_state_broadcaster_spawner],
-                ),
-            ],
-        )
-    )
-    delay_joint_state_broadcaster_spawner_after_ros2_control_node_real = RegisterEventHandler(
-        event_handler=OnProcessStart(
-            target_action=control_node_real,
+            target_action=control_node,
             on_start=[
                 TimerAction(
                     period=3.0,
@@ -267,12 +247,10 @@ def generate_launch_description():
     return LaunchDescription(
         declared_arguments
         + [
-            control_node_mock,
-            control_node_real,
+            control_node,
             robot_state_pub_node,
             rviz_node,
-            delay_joint_state_broadcaster_spawner_after_ros2_control_node_mock,
-            delay_joint_state_broadcaster_spawner_after_ros2_control_node_real,
+            delay_joint_state_broadcaster_spawner_after_ros2_control_node,
         ]
         + delay_robot_controller_spawners_after_joint_state_broadcaster_spawner
         + delay_inactive_robot_controller_spawners_after_joint_state_broadcaster_spawner

--- a/templates/ros2_control/robot_ros2_control.launch.py
+++ b/templates/ros2_control/robot_ros2_control.launch.py
@@ -84,6 +84,13 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
+            "overrun_flags",
+            default_value="true",
+            description="Set to true to manage controller overruns and print warnings. Set to false to disable overrun handling (useful for mock systems).",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
             "mock_sensor_commands",
             default_value="false",
             description="Enable mock command interfaces for sensors used for simple simulations. \
@@ -107,6 +114,7 @@ def generate_launch_description():
     prefix = LaunchConfiguration("prefix")
     attach_world = LaunchConfiguration("attach_world")
     use_mock = LaunchConfiguration("use_mock")
+    overrun_flags = LaunchConfiguration("overrun_flags")
     mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     robot_controller = LaunchConfiguration("robot_controller")
 
@@ -147,7 +155,11 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         output="both",
-        parameters=[robot_description, robot_controllers],
+        parameters=[
+            robot_description,
+            robot_controllers,
+            {"overruns.manage": overrun_flags, "overruns.print_warnings": overrun_flags},
+        ],
     )
     robot_state_pub_node = Node(
         package="robot_state_publisher",

--- a/templates/ros2_control/robot_ros2_control.launch.py
+++ b/templates/ros2_control/robot_ros2_control.launch.py
@@ -20,6 +20,7 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler, TimerAction
+from launch.conditions import IfCondition, UnlessCondition
 from launch.event_handlers import OnProcessExit, OnProcessStart
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
@@ -84,13 +85,6 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "overrun_flags",
-            default_value="true",
-            description="Set to true to manage controller overruns and print warnings. Set to false to disable overrun handling (useful for mock systems).",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
             "mock_sensor_commands",
             default_value="false",
             description="Enable mock command interfaces for sensors used for simple simulations. \
@@ -114,7 +108,6 @@ def generate_launch_description():
     prefix = LaunchConfiguration("prefix")
     attach_world = LaunchConfiguration("attach_world")
     use_mock = LaunchConfiguration("use_mock")
-    overrun_flags = LaunchConfiguration("overrun_flags")
     mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     robot_controller = LaunchConfiguration("robot_controller")
 
@@ -151,15 +144,27 @@ def generate_launch_description():
         [FindPackageShare(description_package), "rviz", "$ROBOT_NAME$.rviz"]
     )
 
-    control_node = Node(
+    control_node_mock = Node(
         package="controller_manager",
         executable="ros2_control_node",
         output="both",
         parameters=[
             robot_description,
             robot_controllers,
-            {"overruns.manage": overrun_flags, "overruns.print_warnings": overrun_flags},
+            {"overruns.manage": False, "overruns.print_warnings": False},
         ],
+        condition=IfCondition(use_mock),
+    )
+    control_node_real = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        output="both",
+        parameters=[
+            robot_description,
+            robot_controllers,
+            {"overruns.manage": True, "overruns.print_warnings": True},
+        ],
+        condition=UnlessCondition(use_mock),
     )
     robot_state_pub_node = Node(
         package="robot_state_publisher",
@@ -204,9 +209,20 @@ def generate_launch_description():
         ]
 
     # Delay loading and activation of `joint_state_broadcaster` after start of ros2_control_node
-    delay_joint_state_broadcaster_spawner_after_ros2_control_node = RegisterEventHandler(
+    delay_joint_state_broadcaster_spawner_after_ros2_control_node_mock = RegisterEventHandler(
         event_handler=OnProcessStart(
-            target_action=control_node,
+            target_action=control_node_mock,
+            on_start=[
+                TimerAction(
+                    period=3.0,
+                    actions=[joint_state_broadcaster_spawner],
+                ),
+            ],
+        )
+    )
+    delay_joint_state_broadcaster_spawner_after_ros2_control_node_real = RegisterEventHandler(
+        event_handler=OnProcessStart(
+            target_action=control_node_real,
             on_start=[
                 TimerAction(
                     period=3.0,
@@ -251,10 +267,12 @@ def generate_launch_description():
     return LaunchDescription(
         declared_arguments
         + [
-            control_node,
+            control_node_mock,
+            control_node_real,
             robot_state_pub_node,
             rviz_node,
-            delay_joint_state_broadcaster_spawner_after_ros2_control_node,
+            delay_joint_state_broadcaster_spawner_after_ros2_control_node_mock,
+            delay_joint_state_broadcaster_spawner_after_ros2_control_node_real,
         ]
         + delay_robot_controller_spawners_after_joint_state_broadcaster_spawner
         + delay_inactive_robot_controller_spawners_after_joint_state_broadcaster_spawner

--- a/templates/ros2_control/start_offline.launch.xml
+++ b/templates/ros2_control/start_offline.launch.xml
@@ -24,5 +24,6 @@ Author: Dr. Denis
   <include file="$(find-pkg-share $(var launch_package))/launch/bringup_control.launch.xml">
     <arg name="use_mock" value="true"/>
     <arg name="start_rviz" value="false"/>
+     <arg name="overrun_flags" value="false"/>
   </include>
 </launch>

--- a/templates/ros2_control/start_offline.launch.xml
+++ b/templates/ros2_control/start_offline.launch.xml
@@ -24,6 +24,5 @@ Author: Dr. Denis
   <include file="$(find-pkg-share $(var launch_package))/launch/bringup_control.launch.xml">
     <arg name="use_mock" value="true"/>
     <arg name="start_rviz" value="false"/>
-     <arg name="overrun_flags" value="false"/>
   </include>
 </launch>


### PR DESCRIPTION
ROS2 Control uses two parameters `overruns.manage` and `overrun.print_warnings` for detecting overruns and printing their outputs. 

These overruns can be verbose and users may want to disable them when working with mock hardware to better debug. 

In this PR, depending on the value of `use_mock` , we use launch the control node either with the overrun parameters set to true or false .

Changes were introduced to the following template files: 

- `templates/ros2_control/bringup_control.launch.xml`
- `templates/ros2_control/robot_ros2_control.launch.py`

Tests about the effectiveness of the flags were done on a separate project using launch files based on these templates.