### PR TITLE
Add --disable-testing flag to workspace create

### DIFF
--- a/docs/rtwcli/index.rst
+++ b/docs/rtwcli/index.rst
@@ -68,6 +68,8 @@ repositories.
         workspace (format: ``KEY=VALUE``). Multiple variables can be specified
         separated by spaces. These variables are exported when the workspace is
         sourced.
+      * ``--disable-testing``: Build the initial workspace with
+        ``-DBUILD_TESTING=OFF`` (skip compiling test targets).
 
 * Minimal example:
 

--- a/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
+++ b/rtwcli/rtw_cmds/rtw_cmds/workspace/create_verb.py
@@ -121,6 +121,7 @@ class CreateVerbArgs:
     user_override_name: str
     has_upstream_ws: bool = False
     ignore_ws_cmd_error: bool = False
+    disable_testing: bool = False
     additional_apt_packages: List[str] = field(default_factory=list)
     no_base_apt_packages: bool = False
     python_packages: List[str] = field(default_factory=list)
@@ -593,6 +594,12 @@ class CreateVerb(VerbExtension):
             default=False,
         )
         parser.add_argument(
+            "--disable-testing",
+            action="store_true",
+            help="Build the workspace with -DBUILD_TESTING=OFF (skip compiling test targets).",
+            default=False,
+        )
+        parser.add_argument(
             "--hostname",
             type=str,
             help=(
@@ -965,16 +972,29 @@ RUN rm -rf /var/lib/apt/lists/*
                 upstream_ws_abs_path = create_args.upstream_ws_abs_path_in_docker
             else:
                 upstream_ws_abs_path = create_args.upstream_ws_abs_path
-            compile_cmds.append(get_compile_cmd(upstream_ws_abs_path, create_args.ros_distro))
+            compile_cmds.append(
+                get_compile_cmd(
+                    upstream_ws_abs_path,
+                    create_args.ros_distro,
+                    disable_testing=create_args.disable_testing,
+                )
+            )
             compile_cmds.append(
                 get_compile_cmd(
                     ws_abs_path,
                     create_args.ros_distro,
                     upstream_ws_abs_path=upstream_ws_abs_path,
+                    disable_testing=create_args.disable_testing,
                 )
             )
         else:
-            compile_cmds.append(get_compile_cmd(ws_abs_path, create_args.ros_distro))
+            compile_cmds.append(
+                get_compile_cmd(
+                    ws_abs_path,
+                    create_args.ros_distro,
+                    disable_testing=create_args.disable_testing,
+                )
+            )
         return rosdep_cmds + compile_cmds
 
     def execute_ws_cmds(

--- a/rtwcli/rtwcli/rtwcli/workspace_utils.py
+++ b/rtwcli/rtwcli/rtwcli/workspace_utils.py
@@ -242,6 +242,7 @@ def get_compile_cmd(
     upstream_ws_abs_path: Union[str, None] = None,
     distro_setup_bash_format: str = "/opt/ros/{distro}/setup.bash",
     upstream_ws_setup_bash_format: str = "{upstream_ws_abs_path}/install/setup.bash",
+    disable_testing: bool = False,
 ) -> List[str]:
     """Return a compile command for the given workspace."""
     if upstream_ws_abs_path:
@@ -250,6 +251,9 @@ def get_compile_cmd(
         )
     else:
         setup_bash_path = distro_setup_bash_format.format(distro=distro)
+    cmake_args = ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
+    if disable_testing:
+        cmake_args.append("-DBUILD_TESTING=OFF")
     compile_ws_cmd = [
         "cd",
         ws_path_abs,
@@ -261,7 +265,7 @@ def get_compile_cmd(
         "build",
         "--symlink-install",
         "--cmake-args",
-        "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+        *cmake_args,
     ]
     return compile_ws_cmd
 


### PR DESCRIPTION
## Summary

Add a `--disable-testing` flag to `rtw workspace create`. When set, the initial
`colcon build` is run with `-DBUILD_TESTING=OFF`, so test targets are not compiled.
Defaults to off — existing behaviour is unchanged.

## Motivation

`rtw workspace create` runs an initial `colcon build` after importing the sources.
With `BUILD_TESTING` on (the ament default), that build also compiles every package's
test targets. A source dependency whose library builds fine but whose **tests** do not
(e.g. a test-only header missing from the released binary of an upstream package) then
fails the whole workspace creation, even though the workspace itself is fine.

`--disable-testing` lets creation complete in that case without hand-editing the
imported tree. `colcon build` does not run tests; this only skips compiling them.

## Changes

- `workspace_utils.get_compile_cmd()` gains a `disable_testing` parameter that appends
  `-DBUILD_TESTING=OFF` to the `colcon build --cmake-args`.
- `rtw workspace create` gains the `--disable-testing` flag, threaded to every compile
  invocation (main and upstream workspace).
- Documented in `docs/rtwcli/index.rst`.

## Testing

- `rtw workspace create --help` lists `--disable-testing`.
- `get_compile_cmd(..., disable_testing=True)` emits
  `--cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF`; the default
  emits only `-DCMAKE_BUILD_TYPE=RelWithDebInfo`.
- Verified end-to-end: a dockerized `rtw workspace create --disable-testing` runs
  `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
  -DBUILD_TESTING=OFF`.
