### PR TITLE
ament_cpplint: check also that copyright is added

### DIFF
--- a/templates/package/.pre-commit-config.yaml
+++ b/templates/package/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
         entry: ament_cpplint
         language: system
         files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
-        args: ["--linelength=100", "--filter=-whitespace/newline"]
+        args: ["--linelength=100", "--filter=-whitespace/newline,-legal/copyright"]
 
   # Cmake hooks
   - repo: local


### PR DESCRIPTION
Updated pre-commit configuration to filter out legal copyright warnings.